### PR TITLE
Add connection timeout

### DIFF
--- a/src/Novell.Directory.Ldap.NETStandard/AsyncExtensions.cs
+++ b/src/Novell.Directory.Ldap.NETStandard/AsyncExtensions.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Net.Sockets;
 using System.Threading.Tasks;
 
 namespace Novell.Directory.Ldap
@@ -21,11 +22,14 @@ namespace Novell.Directory.Ldap
             }
         }
 
-        public static void WaitAndUnwrap(this Task task)
+        public static void WaitAndUnwrap(this Task task, int timeout)
         {
             try
             {
-                task.Wait();
+                if (timeout == 0)
+                    task.Wait();
+                else if (!task.Wait(timeout))
+                    throw new SocketException(258); // WAIT_TIMEOUT
             }
             catch (AggregateException exception)
             {

--- a/src/Novell.Directory.Ldap.NETStandard/Connection.cs
+++ b/src/Novell.Directory.Ldap.NETStandard/Connection.cs
@@ -131,6 +131,12 @@ namespace Novell.Directory.Ldap
             get { return port; }
         }
 
+        internal int ConnectionTimeout
+        {
+            get { return connectionTimeout; }
+            set { connectionTimeout = value; }
+        }
+
         /// <summary> gets the writeSemaphore id used for active bind operation</summary>
         internal int BindSemId => bindSemaphoreId;
 
@@ -255,6 +261,7 @@ namespace Novell.Directory.Ldap
         private bool clientActive = true;
 
         private bool ssl;
+        private int connectionTimeout = 0;
 
         // Indicates we have received a server shutdown unsolicited notification
         private bool unsolSvrShutDnNotification;
@@ -589,14 +596,14 @@ namespace Novell.Directory.Ldap
                                 false,
                                 RemoteCertificateValidationCallback
                             );
-                            sslstream.AuthenticateAsClientAsync(host).WaitAndUnwrap();
+                            sslstream.AuthenticateAsClientAsync(host).WaitAndUnwrap(connectionTimeout);
                             in_Renamed = sslstream;
                             out_Renamed = sslstream;
                         }
                         else
                         {
                             socket = new TcpClient();
-                            socket.ConnectAsync(host, port).WaitAndUnwrap();
+                            socket.ConnectAsync(host, port).WaitAndUnwrap(connectionTimeout);
                             in_Renamed = socket.GetStream();
                             out_Renamed = socket.GetStream();
                         }
@@ -1004,7 +1011,7 @@ namespace Novell.Directory.Ldap
                     true,
                     RemoteCertificateValidationCallback
                 );
-                sslstream.AuthenticateAsClientAsync(host).WaitAndUnwrap();
+                sslstream.AuthenticateAsClientAsync(host).WaitAndUnwrap(connectionTimeout);
                 in_Renamed = sslstream;
                 out_Renamed = sslstream;
                 startReader();

--- a/src/Novell.Directory.Ldap.NETStandard/LdapConnection.cs
+++ b/src/Novell.Directory.Ldap.NETStandard/LdapConnection.cs
@@ -299,6 +299,19 @@ namespace Novell.Directory.Ldap
             set { conn.Ssl = value; }
         }
 
+        /// <summary>
+        ///     Connection timeout in milliseconds, default is 0 which will use
+        ///     the platform default timeout for TCP connections.
+        /// </summary>
+        /// <returns>
+        ///     True if SSL is on
+        ///     False if its not on
+        /// </returns>
+        public int ConnectionTimeout
+        {
+            get { return conn.ConnectionTimeout; }
+            set { conn.ConnectionTimeout = value; }
+        }
 
         /// <summary>
         ///     Indicates whether the object has authenticated to the connected Ldap


### PR DESCRIPTION
This adds an explicit connection timeout. Windows seems to automatically timeout requests after 3 sec but on Linux/Mono it can take over 2 minutes for the automatic timeout. This gives you the ability to specify a value directly, however only values less than the automatic timeout will have any affect.