### PR TITLE
GetRootDseInfo extension method for ILdapConnection, and a bunch of cleanups

### DIFF
--- a/src/Novell.Directory.Ldap.NETStandard/Connection.cs
+++ b/src/Novell.Directory.Ldap.NETStandard/Connection.cs
@@ -148,7 +148,7 @@ namespace Novell.Directory.Ldap
 
         static Connection()
         {
-            Sdk = new StringBuilder("2.2.1").ToString();
+            Sdk = "2.2.1";
             Protocol = 3;
         }
 

--- a/src/Novell.Directory.Ldap.NETStandard/Connection.cs
+++ b/src/Novell.Directory.Ldap.NETStandard/Connection.cs
@@ -723,7 +723,7 @@ namespace Novell.Directory.Ldap
             _messages.Add(info);
 
             // For bind requests, if not connected, attempt to reconnect
-            if (info.BindRequest && Connected == false && (object)Host != null)
+            if (info.BindRequest && Connected == false && Host != null)
             {
                 Connect(Host, Port, info.MessageId);
             }

--- a/src/Novell.Directory.Ldap.NETStandard/Controls/LdapSortControl.cs
+++ b/src/Novell.Directory.Ldap.NETStandard/Controls/LdapSortControl.cs
@@ -114,7 +114,7 @@ namespace Novell.Directory.Ldap.Controls
 
                 key.Add(new Asn1OctetString(keys[i].Key));
 
-                if ((object)keys[i].MatchRule != null)
+                if (keys[i].MatchRule != null)
                 {
                     key.Add(new Asn1Tagged(
                         new Asn1Identifier(Asn1Identifier.Context, false, OrderingRule),

--- a/src/Novell.Directory.Ldap.NETStandard/Controls/LdapVirtualListControl.cs
+++ b/src/Novell.Directory.Ldap.NETStandard/Controls/LdapVirtualListControl.cs
@@ -382,7 +382,7 @@ namespace Novell.Directory.Ldap.Controls
 
             /* Add the optional context string if one is available.
             */
-            if ((object)_mContext != null)
+            if (_mContext != null)
             {
                 _mVlvRequest.Add(new Asn1OctetString(_mContext));
             }
@@ -417,7 +417,7 @@ namespace Novell.Directory.Ldap.Controls
 
             /* Add the optional context string if one is available.
             */
-            if ((object)_mContext != null)
+            if (_mContext != null)
             {
                 _mVlvRequest.Add(new Asn1OctetString(_mContext));
             }

--- a/src/Novell.Directory.Ldap.NETStandard/ILdapConnection.ExtensionMethods.cs
+++ b/src/Novell.Directory.Ldap.NETStandard/ILdapConnection.ExtensionMethods.cs
@@ -1,0 +1,25 @@
+﻿namespace Novell.Directory.Ldap
+{
+    /// <summary>
+    /// Extension Methods for <see cref="ILdapConnection"/> to
+    /// avoid bloating that interface.
+    /// </summary>
+    public static class LdapConnectionExtensionMethods
+    {
+        /// <summary>
+        /// Get some common Attributes from the Root DSE.
+        /// This is really just a specialized <see cref="LdapSearchRequest"/>
+        /// to handle getting some commonly requested information.
+        /// </summary>
+        public static RootDseInfo GetRootDseInfo(this ILdapConnection conn)
+        {
+            var searchResults = conn.Search("", LdapConnection.ScopeBase, "(objectClass=*)", new string[] { "*", "supportedExtension" }, false);
+            if (searchResults.HasMore())
+            {
+                var sr = searchResults.Next();
+                return new RootDseInfo(sr);
+            }
+            return null;
+        }
+    }
+}

--- a/src/Novell.Directory.Ldap.NETStandard/LdapAttribute.cs
+++ b/src/Novell.Directory.Ldap.NETStandard/LdapAttribute.cs
@@ -101,7 +101,7 @@ namespace Novell.Directory.Ldap
         /// </param>
         public LdapAttribute(string attrName)
         {
-            if ((object)attrName == null)
+            if (attrName == null)
             {
                 throw new ArgumentException("Attribute name cannot be null");
             }
@@ -150,7 +150,7 @@ namespace Novell.Directory.Ldap
         public LdapAttribute(string attrName, string attrString)
             : this(attrName)
         {
-            if ((object)attrString == null)
+            if (attrString == null)
             {
                 throw new ArgumentException("Attribute value cannot be null");
             }
@@ -191,7 +191,7 @@ namespace Novell.Directory.Ldap
             {
                 try
                 {
-                    if ((object)attrStrings[i] == null)
+                    if (attrStrings[i] == null)
                     {
                         throw new ArgumentException("Attribute value " + "at array index " + i + " cannot be null");
                     }
@@ -475,7 +475,7 @@ namespace Novell.Directory.Ldap
         /// </param>
         public virtual void AddValue(string attrString)
         {
-            if ((object)attrString == null)
+            if (attrString == null)
             {
                 throw new ArgumentException("Attribute value cannot be null");
             }
@@ -522,7 +522,7 @@ namespace Novell.Directory.Ldap
         /// </param>
         public void AddBase64Value(string attrString)
         {
-            if ((object)attrString == null)
+            if (attrString == null)
             {
                 throw new ArgumentException("Attribute value cannot be null");
             }
@@ -586,7 +586,7 @@ namespace Novell.Directory.Ldap
         /// </param>
         public void AddUrlValue(string url)
         {
-            if ((object)url == null)
+            if (url == null)
             {
                 throw new ArgumentException("Attribute URL cannot be null");
             }
@@ -679,7 +679,7 @@ namespace Novell.Directory.Ldap
         /// </returns>
         public static string GetBaseName(string attrName)
         {
-            if ((object)attrName == null)
+            if (attrName == null)
             {
                 throw new ArgumentException("Attribute name cannot be null");
             }
@@ -721,7 +721,7 @@ namespace Novell.Directory.Ldap
         /// </returns>
         public static string[] GetSubtypes(string attrName)
         {
-            if ((object)attrName == null)
+            if (attrName == null)
             {
                 throw new ArgumentException("Attribute name cannot be null");
             }
@@ -758,7 +758,7 @@ namespace Novell.Directory.Ldap
         /// </returns>
         public bool HasSubtype(string subtype)
         {
-            if ((object)subtype == null)
+            if (subtype == null)
             {
                 throw new ArgumentException("subtype cannot be null");
             }
@@ -804,7 +804,7 @@ namespace Novell.Directory.Ldap
             {
                 for (var j = 0; j < _subTypes.Length; j++)
                 {
-                    if ((object)_subTypes[j] == null)
+                    if (_subTypes[j] == null)
                     {
                         throw new ArgumentException("subtype " + "at array index " + i + " cannot be null");
                     }
@@ -833,7 +833,7 @@ namespace Novell.Directory.Ldap
         /// </param>
         public virtual void RemoveValue(string attrString)
         {
-            if ((object)attrString == null)
+            if (attrString == null)
             {
                 throw new ArgumentException("Attribute value cannot be null");
             }

--- a/src/Novell.Directory.Ldap.NETStandard/LdapAttributeSchema.cs
+++ b/src/Novell.Directory.Ldap.NETStandard/LdapAttributeSchema.cs
@@ -173,22 +173,22 @@ namespace Novell.Directory.Ldap
                     names = parser.Names;
                 }
 
-                if ((object)parser.Id != null)
+                if (parser.Id != null)
                 {
                     Oid = parser.Id;
                 }
 
-                if ((object)parser.Description != null)
+                if (parser.Description != null)
                 {
                     Description = parser.Description;
                 }
 
-                if ((object)parser.Syntax != null)
+                if (parser.Syntax != null)
                 {
                     SyntaxString = parser.Syntax;
                 }
 
-                if ((object)parser.Superior != null)
+                if (parser.Superior != null)
                 {
                     Superior = parser.Superior;
                 }
@@ -310,7 +310,7 @@ namespace Novell.Directory.Ldap
             var valueBuffer = new StringBuilder("( ");
             string token;
 
-            if ((object)(token = Id) != null)
+            if ((token = Id) != null)
             {
                 valueBuffer.Append(token);
             }
@@ -336,7 +336,7 @@ namespace Novell.Directory.Ldap
                 }
             }
 
-            if ((object)(token = Description) != null)
+            if ((token = Description) != null)
             {
                 valueBuffer.Append(" DESC ");
                 valueBuffer.Append("'" + token + "'");
@@ -347,31 +347,31 @@ namespace Novell.Directory.Ldap
                 valueBuffer.Append(" OBSOLETE");
             }
 
-            if ((object)(token = Superior) != null)
+            if ((token = Superior) != null)
             {
                 valueBuffer.Append(" SUP ");
                 valueBuffer.Append("'" + token + "'");
             }
 
-            if ((object)(token = EqualityMatchingRule) != null)
+            if ((token = EqualityMatchingRule) != null)
             {
                 valueBuffer.Append(" EQUALITY ");
                 valueBuffer.Append("'" + token + "'");
             }
 
-            if ((object)(token = OrderingMatchingRule) != null)
+            if ((token = OrderingMatchingRule) != null)
             {
                 valueBuffer.Append(" ORDERING ");
                 valueBuffer.Append("'" + token + "'");
             }
 
-            if ((object)(token = SubstringMatchingRule) != null)
+            if ((token = SubstringMatchingRule) != null)
             {
                 valueBuffer.Append(" SUBSTR ");
                 valueBuffer.Append("'" + token + "'");
             }
 
-            if ((object)(token = SyntaxString) != null)
+            if ((token = SyntaxString) != null)
             {
                 valueBuffer.Append(" SYNTAX ");
                 valueBuffer.Append(token);
@@ -419,7 +419,7 @@ namespace Novell.Directory.Ldap
             while (en.MoveNext())
             {
                 token = (string)en.Current;
-                if ((object)token != null)
+                if (token != null)
                 {
                     valueBuffer.Append(" " + token);
                     strArray = GetQualifier(token);

--- a/src/Novell.Directory.Ldap.NETStandard/LdapAttributeSet.cs
+++ b/src/Novell.Directory.Ldap.NETStandard/LdapAttributeSet.cs
@@ -356,7 +356,7 @@ namespace Novell.Directory.Ldap
                 attributeName = ((LdapAttribute)objectRenamed).Name;
             }
 
-            if ((object)attributeName == null)
+            if (attributeName == null)
             {
                 return false;
             }

--- a/src/Novell.Directory.Ldap.NETStandard/LdapConnection.cs
+++ b/src/Novell.Directory.Ldap.NETStandard/LdapConnection.cs
@@ -783,7 +783,7 @@ namespace Novell.Directory.Ldap
         public void Bind(int version, string dn, string passwd, LdapConstraints cons)
         {
             byte[] pw = null;
-            if ((object)passwd != null)
+            if (passwd != null)
             {
                 var encoder = Encoding.GetEncoding("utf-8");
                 var ibytes = encoder.GetBytes(passwd);
@@ -1860,7 +1860,7 @@ namespace Novell.Directory.Ldap
                 throw new ArgumentException("The LdapEntry parameter" + " cannot be null");
             }
 
-            if ((object)entry.Dn == null)
+            if (entry.Dn == null)
             {
                 throw new ArgumentException("The DN value must be present" + " in the LdapEntry object");
             }
@@ -1954,7 +1954,7 @@ namespace Novell.Directory.Ldap
                 cons = _defSearchCons;
             }
 
-            if ((object)dn == null)
+            if (dn == null)
             {
                 dn = string.Empty;
             }
@@ -1983,7 +1983,7 @@ namespace Novell.Directory.Ldap
             // For bind requests, if not connected, attempt to reconnect
             if (!Connection.Connected)
             {
-                if ((object)Connection.Host != null)
+                if (Connection.Host != null)
                 {
                     Connection.Connect(Connection.Host, Connection.Port);
                 }
@@ -2159,7 +2159,7 @@ namespace Novell.Directory.Ldap
                 throw new ArgumentException("compare: Exactly one value " + "must be present in the LdapAttribute");
             }
 
-            if ((object)dn == null)
+            if (dn == null)
             {
                 // Invalid parameter
                 throw new ArgumentException("compare: DN cannot be null");
@@ -2221,7 +2221,7 @@ namespace Novell.Directory.Ldap
         /// </exception>
         public LdapResponseQueue Delete(string dn, LdapResponseQueue queue, LdapConstraints cons)
         {
-            if ((object)dn == null)
+            if (dn == null)
             {
                 // Invalid DN parameter
                 throw new ArgumentException(ExceptionMessages.DnParamError);
@@ -2341,7 +2341,7 @@ namespace Novell.Directory.Ldap
             }
 
             // error check the parameters
-            if ((object)op.GetId() == null)
+            if (op.GetId() == null)
             {
                 // Invalid extended operation parameter, no OID specified
                 throw new ArgumentException(ExceptionMessages.OpParamError);
@@ -2479,7 +2479,7 @@ namespace Novell.Directory.Ldap
         public LdapResponseQueue Modify(string dn, LdapModification[] mods, LdapResponseQueue queue,
             LdapConstraints cons)
         {
-            if ((object)dn == null)
+            if (dn == null)
             {
                 // Invalid DN parameter
                 throw new ArgumentException(ExceptionMessages.DnParamError);
@@ -2688,7 +2688,7 @@ namespace Novell.Directory.Ldap
         public LdapResponseQueue Rename(string dn, string newRdn, string newParentdn, bool deleteOldRdn,
             LdapResponseQueue queue, LdapConstraints cons)
         {
-            if ((object)dn == null || (object)newRdn == null)
+            if (dn == null || newRdn == null)
             {
                 // Invalid DN or RDN parameter
                 throw new ArgumentException(ExceptionMessages.RdnParamError);
@@ -2795,7 +2795,7 @@ namespace Novell.Directory.Ldap
         public LdapSearchQueue Search(string @base, int scope, string filter, string[] attrs, bool typesOnly,
             LdapSearchQueue queue, LdapSearchConstraints cons)
         {
-            if ((object)filter == null)
+            if (filter == null)
             {
                 filter = "objectclass=*";
             }

--- a/src/Novell.Directory.Ldap.NETStandard/LdapControl.cs
+++ b/src/Novell.Directory.Ldap.NETStandard/LdapControl.cs
@@ -75,7 +75,7 @@ namespace Novell.Directory.Ldap
         [CLSCompliant(false)]
         public LdapControl(string oid, bool critical, byte[] values)
         {
-            if ((object)oid == null)
+            if (oid == null)
             {
                 throw new ArgumentException("An OID must be specified");
             }

--- a/src/Novell.Directory.Ldap.NETStandard/LdapControl.cs
+++ b/src/Novell.Directory.Ldap.NETStandard/LdapControl.cs
@@ -103,7 +103,7 @@ namespace Novell.Directory.Ldap
         /// <returns>
         ///     The object ID of the control.
         /// </returns>
-        public string Id => new StringBuilder(Asn1Object.ControlType.StringValue()).ToString();
+        public string Id => Asn1Object.ControlType.StringValue();
 
         /// <summary>
         ///     Returns whether the control is critical for the operation.

--- a/src/Novell.Directory.Ldap.NETStandard/LdapDITContentRuleSchema.cs
+++ b/src/Novell.Directory.Ldap.NETStandard/LdapDITContentRuleSchema.cs
@@ -129,12 +129,12 @@ namespace Novell.Directory.Ldap
                     parser.Names.CopyTo(names, 0);
                 }
 
-                if ((object)parser.Id != null)
+                if (parser.Id != null)
                 {
                     Oid = parser.Id;
                 }
 
-                if ((object)parser.Description != null)
+                if (parser.Description != null)
                 {
                     Description = parser.Description;
                 }
@@ -226,7 +226,7 @@ namespace Novell.Directory.Ldap
             var valueBuffer = new StringBuilder("( ");
             string token;
 
-            if ((object)(token = Id) != null)
+            if ((token = Id) != null)
             {
                 valueBuffer.Append(token);
             }
@@ -252,7 +252,7 @@ namespace Novell.Directory.Ldap
                 }
             }
 
-            if ((object)(token = Description) != null)
+            if ((token = Description) != null)
             {
                 valueBuffer.Append(" DESC ");
                 valueBuffer.Append("'" + token + "'");

--- a/src/Novell.Directory.Ldap.NETStandard/LdapDITStructureRuleSchema.cs
+++ b/src/Novell.Directory.Ldap.NETStandard/LdapDITStructureRuleSchema.cs
@@ -115,12 +115,12 @@ namespace Novell.Directory.Ldap
                     parser.Names.CopyTo(names, 0);
                 }
 
-                if ((object)parser.Id != null)
+                if (parser.Id != null)
                 {
                     RuleId = int.Parse(parser.Id);
                 }
 
-                if ((object)parser.Description != null)
+                if (parser.Description != null)
                 {
                     Description = parser.Description;
                 }
@@ -131,7 +131,7 @@ namespace Novell.Directory.Ldap
                     parser.Superiors.CopyTo(Superiors, 0);
                 }
 
-                if ((object)parser.NameForm != null)
+                if (parser.NameForm != null)
                 {
                     NameForm = parser.NameForm;
                 }
@@ -220,7 +220,7 @@ namespace Novell.Directory.Ldap
                 }
             }
 
-            if ((object)(token = Description) != null)
+            if ((token = Description) != null)
             {
                 valueBuffer.Append(" DESC ");
                 valueBuffer.Append("'" + token + "'");
@@ -231,7 +231,7 @@ namespace Novell.Directory.Ldap
                 valueBuffer.Append(" OBSOLETE");
             }
 
-            if ((object)(token = NameForm) != null)
+            if ((token = NameForm) != null)
             {
                 valueBuffer.Append(" FORM ");
                 valueBuffer.Append("'" + token + "'");

--- a/src/Novell.Directory.Ldap.NETStandard/LdapEntry.cs
+++ b/src/Novell.Directory.Ldap.NETStandard/LdapEntry.cs
@@ -86,7 +86,7 @@ namespace Novell.Directory.Ldap
         /// </param>
         public LdapEntry(string dn, LdapAttributeSet attrs)
         {
-            if ((object)dn == null)
+            if (dn == null)
             {
                 dn = string.Empty;
             }

--- a/src/Novell.Directory.Ldap.NETStandard/LdapException.cs
+++ b/src/Novell.Directory.Ldap.NETStandard/LdapException.cs
@@ -1116,7 +1116,7 @@ namespace Novell.Directory.Ldap
         {
             get
             {
-                if ((object)_serverMessage != null && _serverMessage.Length == 0)
+                if (_serverMessage != null && _serverMessage.Length == 0)
                 {
                     return null;
                 }
@@ -1264,7 +1264,7 @@ namespace Novell.Directory.Ldap
             }
 
             // Add server message
-            if ((object)_serverMessage != null && _serverMessage.Length != 0)
+            if (!string.IsNullOrEmpty(_serverMessage))
             {
                 tmsg = ResourcesHandler.GetMessage("SERVER_MSG", new object[] {exception, _serverMessage });
 
@@ -1278,7 +1278,7 @@ namespace Novell.Directory.Ldap
             }
 
             // Add Matched DN message
-            if ((object)MatchedDn != null)
+            if (MatchedDn != null)
             {
                 tmsg = ResourcesHandler.GetMessage("MATCHED_DN", new object[] {exception, MatchedDn });
 

--- a/src/Novell.Directory.Ldap.NETStandard/LdapMatchingRuleSchema.cs
+++ b/src/Novell.Directory.Ldap.NETStandard/LdapMatchingRuleSchema.cs
@@ -120,7 +120,7 @@ namespace Novell.Directory.Ldap
                 Description = matchParser.Description;
                 Obsolete = matchParser.Obsolete;
                 SyntaxString = matchParser.Syntax;
-                if ((object)rawMatchingRuleUse != null)
+                if (rawMatchingRuleUse != null)
                 {
                     var matchUseParser = new SchemaParser(rawMatchingRuleUse);
                     Attributes = matchUseParser.Applies;
@@ -162,7 +162,7 @@ namespace Novell.Directory.Ldap
             var valueBuffer = new StringBuilder("( ");
             string token;
 
-            if ((object)(token = Id) != null)
+            if ((token = Id) != null)
             {
                 valueBuffer.Append(token);
             }
@@ -188,7 +188,7 @@ namespace Novell.Directory.Ldap
                 }
             }
 
-            if ((object)(token = Description) != null)
+            if ((token = Description) != null)
             {
                 valueBuffer.Append(" DESC ");
                 valueBuffer.Append("'" + token + "'");
@@ -199,7 +199,7 @@ namespace Novell.Directory.Ldap
                 valueBuffer.Append(" OBSOLETE");
             }
 
-            if ((object)(token = SyntaxString) != null)
+            if ((token = SyntaxString) != null)
             {
                 valueBuffer.Append(" SYNTAX ");
                 valueBuffer.Append(token);

--- a/src/Novell.Directory.Ldap.NETStandard/LdapMatchingRuleUseSchema.cs
+++ b/src/Novell.Directory.Ldap.NETStandard/LdapMatchingRuleUseSchema.cs
@@ -138,7 +138,7 @@ namespace Novell.Directory.Ldap
             var valueBuffer = new StringBuilder("( ");
             string token;
 
-            if ((object)(token = Id) != null)
+            if ((token = Id) != null)
             {
                 valueBuffer.Append(token);
             }
@@ -164,7 +164,7 @@ namespace Novell.Directory.Ldap
                 }
             }
 
-            if ((object)(token = Description) != null)
+            if ((token = Description) != null)
             {
                 valueBuffer.Append(" DESC ");
                 valueBuffer.Append("'" + token + "'");

--- a/src/Novell.Directory.Ldap.NETStandard/LdapMessage.cs
+++ b/src/Novell.Directory.Ldap.NETStandard/LdapMessage.cs
@@ -511,7 +511,7 @@ namespace Novell.Directory.Ldap
         {
             get
             {
-                if ((object)_stringTag != null)
+                if (_stringTag != null)
                 {
                     return _stringTag;
                 }

--- a/src/Novell.Directory.Ldap.NETStandard/LdapModifyDNRequest.cs
+++ b/src/Novell.Directory.Ldap.NETStandard/LdapModifyDNRequest.cs
@@ -75,7 +75,7 @@ namespace Novell.Directory.Ldap
             : base(
                 ModifyRdnRequest,
                 new RfcModifyDnRequest(new RfcLdapDn(dn), new RfcRelativeLdapDn(newRdn), new Asn1Boolean(deleteOldRdn),
-                    (object)newParentdn != null ? new RfcLdapDn(newParentdn) : null), cont)
+                    newParentdn != null ? new RfcLdapDn(newParentdn) : null), cont)
         {
         }
 

--- a/src/Novell.Directory.Ldap.NETStandard/LdapNameFormSchema.cs
+++ b/src/Novell.Directory.Ldap.NETStandard/LdapNameFormSchema.cs
@@ -124,14 +124,14 @@ namespace Novell.Directory.Ldap
                     parser.Names.CopyTo(names, 0);
                 }
 
-                if ((object)parser.Id != null)
+                if (parser.Id != null)
                 {
-                    Oid = new StringBuilder(parser.Id).ToString();
+                    Oid = parser.Id;
                 }
 
-                if ((object)parser.Description != null)
+                if (parser.Description != null)
                 {
-                    Description = new StringBuilder(parser.Description).ToString();
+                    Description = parser.Description;
                 }
 
                 if (parser.Required != null)
@@ -146,7 +146,7 @@ namespace Novell.Directory.Ldap
                     parser.Optional.CopyTo(OptionalNamingAttributes, 0);
                 }
 
-                if ((object)parser.ObjectClass != null)
+                if (parser.ObjectClass != null)
                 {
                     ObjectClass = parser.ObjectClass;
                 }

--- a/src/Novell.Directory.Ldap.NETStandard/LdapNameFormSchema.cs
+++ b/src/Novell.Directory.Ldap.NETStandard/LdapNameFormSchema.cs
@@ -206,7 +206,7 @@ namespace Novell.Directory.Ldap
             var valueBuffer = new StringBuilder("( ");
             string token;
 
-            if ((object)(token = Id) != null)
+            if ((token = Id) != null)
             {
                 valueBuffer.Append(token);
             }
@@ -232,7 +232,7 @@ namespace Novell.Directory.Ldap
                 }
             }
 
-            if ((object)(token = Description) != null)
+            if ((token = Description) != null)
             {
                 valueBuffer.Append(" DESC ");
                 valueBuffer.Append("'" + token + "'");
@@ -243,7 +243,7 @@ namespace Novell.Directory.Ldap
                 valueBuffer.Append(" OBSOLETE");
             }
 
-            if ((object)(token = ObjectClass) != null)
+            if ((token = ObjectClass) != null)
             {
                 valueBuffer.Append(" OC ");
                 valueBuffer.Append("'" + token + "'");

--- a/src/Novell.Directory.Ldap.NETStandard/LdapObjectClassSchema.cs
+++ b/src/Novell.Directory.Ldap.NETStandard/LdapObjectClassSchema.cs
@@ -149,12 +149,12 @@ namespace Novell.Directory.Ldap
                     parser.Names.CopyTo(names, 0);
                 }
 
-                if ((object)parser.Id != null)
+                if (parser.Id != null)
                 {
                     Oid = parser.Id;
                 }
 
-                if ((object)parser.Description != null)
+                if (parser.Description != null)
                 {
                     Description = parser.Description;
                 }
@@ -250,7 +250,7 @@ namespace Novell.Directory.Ldap
             var valueBuffer = new StringBuilder("( ");
             string token;
 
-            if ((object)(token = Id) != null)
+            if ((token = Id) != null)
             {
                 valueBuffer.Append(token);
             }
@@ -276,7 +276,7 @@ namespace Novell.Directory.Ldap
                 }
             }
 
-            if ((object)(token = Description) != null)
+            if ((token = Description) != null)
             {
                 valueBuffer.Append(" DESC ");
                 valueBuffer.Append("'" + token + "'");

--- a/src/Novell.Directory.Ldap.NETStandard/LdapReferralException.cs
+++ b/src/Novell.Directory.Ldap.NETStandard/LdapReferralException.cs
@@ -262,7 +262,7 @@ namespace Novell.Directory.Ldap
             var msg = GetExceptionString("LdapReferralException");
 
             // Add failed referral information
-            if ((object)FailedReferral != null)
+            if (FailedReferral != null)
             {
                 tmsg = ResourcesHandler.GetMessage(
                     "FAILED_REFERRAL",

--- a/src/Novell.Directory.Ldap.NETStandard/LdapResponse.cs
+++ b/src/Novell.Directory.Ldap.NETStandard/LdapResponse.cs
@@ -220,11 +220,11 @@ namespace Novell.Directory.Ldap
                         {
                             // get the referral URL
                             var urlRef = new LdapUrl(aRef);
-                            if ((object)urlRef.GetDn() == null)
+                            if (urlRef.GetDn() == null)
                             {
                                 var origMsg = Asn1Object.RequestingMessage.Asn1Object;
                                 string dn;
-                                if ((object)(dn = origMsg.RequestDn) != null)
+                                if ((dn = origMsg.RequestDn) != null)
                                 {
                                     urlRef.SetDn(dn);
                                     aRef = urlRef.ToString();
@@ -388,12 +388,12 @@ namespace Novell.Directory.Ldap
         {
             Asn1Sequence ret;
 
-            if ((object)matchedDn == null)
+            if (matchedDn == null)
             {
                 matchedDn = string.Empty;
             }
 
-            if ((object)serverMessage == null)
+            if (serverMessage == null)
             {
                 serverMessage = string.Empty;
             }

--- a/src/Novell.Directory.Ldap.NETStandard/LdapSchema.cs
+++ b/src/Novell.Directory.Ldap.NETStandard/LdapSchema.cs
@@ -453,7 +453,7 @@ namespace Novell.Directory.Ldap
         /// </param>
         private LdapSchemaElement GetSchemaElement(int schemaType, string key)
         {
-            if ((object)key == null || key.ToUpper().Equals(string.Empty.ToUpper()))
+            if (string.IsNullOrEmpty(key))
             {
                 return null;
             }

--- a/src/Novell.Directory.Ldap.NETStandard/LdapSyntaxSchema.cs
+++ b/src/Novell.Directory.Ldap.NETStandard/LdapSyntaxSchema.cs
@@ -86,12 +86,12 @@ namespace Novell.Directory.Ldap
             {
                 var parser = new SchemaParser(raw);
 
-                if ((object)parser.Id != null)
+                if (parser.Id != null)
                 {
                     Oid = parser.Id;
                 }
 
-                if ((object)parser.Description != null)
+                if (parser.Description != null)
                 {
                     Description = parser.Description;
                 }
@@ -123,12 +123,12 @@ namespace Novell.Directory.Ldap
             var valueBuffer = new StringBuilder("( ");
             string token;
 
-            if ((object)(token = Id) != null)
+            if ((token = Id) != null)
             {
                 valueBuffer.Append(token);
             }
 
-            if ((object)(token = Description) != null)
+            if ((token = Description) != null)
             {
                 valueBuffer.Append(" DESC ");
                 valueBuffer.Append("'" + token + "'");

--- a/src/Novell.Directory.Ldap.NETStandard/LdapUrl.cs
+++ b/src/Novell.Directory.Ldap.NETStandard/LdapUrl.cs
@@ -589,7 +589,7 @@ namespace Novell.Directory.Ldap
                 url.Append(":" + _port);
             }
 
-            if ((object)_dn == null && AttributeArray == null && Scope == DefaultScope && (object)Filter == null &&
+            if (_dn == null && AttributeArray == null && Scope == DefaultScope && Filter == null &&
                 Extensions == null)
 
             {
@@ -598,13 +598,13 @@ namespace Novell.Directory.Ldap
 
             url.Append("/");
 
-            if ((object)_dn != null)
+            if (_dn != null)
 
             {
                 url.Append(_dn);
             }
 
-            if (AttributeArray == null && Scope == DefaultScope && (object)Filter == null && Extensions == null)
+            if (AttributeArray == null && Scope == DefaultScope && Filter == null && Extensions == null)
 
             {
                 return url.ToString();
@@ -632,7 +632,7 @@ namespace Novell.Directory.Ldap
                 }
             }
 
-            if (Scope == DefaultScope && (object)Filter == null && Extensions == null)
+            if (Scope == DefaultScope && Filter == null && Extensions == null)
 
             {
                 return url.ToString();
@@ -658,7 +658,7 @@ namespace Novell.Directory.Ldap
                 }
             }
 
-            if ((object)Filter == null && Extensions == null)
+            if (Filter == null && Extensions == null)
 
             {
                 return url.ToString();
@@ -666,7 +666,7 @@ namespace Novell.Directory.Ldap
 
             // filter
 
-            if ((object)Filter == null)
+            if (Filter == null)
 
             {
                 url.Append("?");
@@ -802,7 +802,7 @@ namespace Novell.Directory.Ldap
 
             var scanEnd = url.Length;
 
-            if ((object)url == null)
+            if (url == null)
 
             {
                 throw new UriFormatException("LdapUrl: URL cannot be null");

--- a/src/Novell.Directory.Ldap.NETStandard/Rfc2251/RfcAddRequest.cs
+++ b/src/Novell.Directory.Ldap.NETStandard/Rfc2251/RfcAddRequest.cs
@@ -77,7 +77,7 @@ namespace Novell.Directory.Ldap.Rfc2251
             : base(origRequest, origRequest.Length)
         {
             // Replace the base if specified, otherwise keep original base
-            if ((object)baseRenamed != null)
+            if (baseRenamed != null)
             {
                 set_Renamed(0, new RfcLdapDn(baseRenamed));
             }

--- a/src/Novell.Directory.Ldap.NETStandard/Rfc2251/RfcBindRequest.cs
+++ b/src/Novell.Directory.Ldap.NETStandard/Rfc2251/RfcBindRequest.cs
@@ -81,7 +81,7 @@ namespace Novell.Directory.Ldap.Rfc2251
             : base(origRequest, origRequest.Length)
         {
             // Replace the dn if specified, otherwise keep original base
-            if ((object)baseRenamed != null)
+            if (baseRenamed != null)
             {
                 set_Renamed(1, new RfcLdapDn(baseRenamed));
             }

--- a/src/Novell.Directory.Ldap.NETStandard/Rfc2251/RfcCompareRequest.cs
+++ b/src/Novell.Directory.Ldap.NETStandard/Rfc2251/RfcCompareRequest.cs
@@ -69,7 +69,7 @@ namespace Novell.Directory.Ldap.Rfc2251
             : base(origRequest, origRequest.Length)
         {
             // Replace the base if specified, otherwise keep original base
-            if ((object)baseRenamed != null)
+            if (baseRenamed != null)
             {
                 set_Renamed(0, new RfcLdapDn(baseRenamed));
             }

--- a/src/Novell.Directory.Ldap.NETStandard/Rfc2251/RfcDelRequest.cs
+++ b/src/Novell.Directory.Ldap.NETStandard/Rfc2251/RfcDelRequest.cs
@@ -72,7 +72,7 @@ namespace Novell.Directory.Ldap.Rfc2251
 
         public IRfcRequest DupRequest(string baseRenamed, string filter, bool request)
         {
-            if ((object)baseRenamed == null)
+            if (baseRenamed == null)
             {
                 return new RfcDelRequest(ByteValue());
             }

--- a/src/Novell.Directory.Ldap.NETStandard/Rfc2251/RfcFilter.cs
+++ b/src/Novell.Directory.Ldap.NETStandard/Rfc2251/RfcFilter.cs
@@ -146,9 +146,9 @@ namespace Novell.Directory.Ldap.Rfc2251
         /// <summary> Parses an RFC 2251 filter string into an ASN.1 Ldap Filter object.</summary>
         private Asn1Tagged Parse(string filterExpr)
         {
-            if ((object)filterExpr == null || filterExpr.Equals(string.Empty))
+            if (string.IsNullOrEmpty(filterExpr))
             {
-                filterExpr = new StringBuilder("(objectclass=*)").ToString();
+                filterExpr = "(objectclass=*)";
             }
 
             int idx;
@@ -296,7 +296,7 @@ namespace Novell.Directory.Ldap.Rfc2251
                                 var tokCnt = sub.Count;
                                 var cnt = 0;
 
-                                var lastTok = new StringBuilder(string.Empty).ToString();
+                                var lastTok = string.Empty;
 
                                 while (sub.HasMoreTokens())
                                 {

--- a/src/Novell.Directory.Ldap.NETStandard/Rfc2251/RfcFilter.cs
+++ b/src/Novell.Directory.Ldap.NETStandard/Rfc2251/RfcFilter.cs
@@ -395,8 +395,8 @@ namespace Novell.Directory.Ldap.Rfc2251
                             tag = new Asn1Tagged(
                                 new Asn1Identifier(Asn1Identifier.Context, true, ExtensibleMatch),
                                 new RfcMatchingRuleAssertion(
-                                    (object)matchingRule == null ? null : new RfcMatchingRuleId(matchingRule),
-                                    (object)type == null ? null : new RfcAttributeDescription(type),
+                                    matchingRule == null ? null : new RfcMatchingRuleId(matchingRule),
+                                    type == null ? null : new RfcAttributeDescription(type),
                                     new RfcAssertionValue(UnescapeString(valueRenamed)),
                                     dnAttributes == false ? null : new Asn1Boolean(true)), false);
                             break;
@@ -834,8 +834,8 @@ namespace Novell.Directory.Ldap.Rfc2251
             Asn1Object current = new Asn1Tagged(
                 new Asn1Identifier(Asn1Identifier.Context, true, ExtensibleMatch),
                 new RfcMatchingRuleAssertion(
-                    (object)matchingRule == null ? null : new RfcMatchingRuleId(matchingRule),
-                    (object)attrName == null ? null : new RfcAttributeDescription(attrName),
+                    matchingRule == null ? null : new RfcMatchingRuleId(matchingRule),
+                    attrName == null ? null : new RfcAttributeDescription(attrName),
                     new RfcAssertionValue(valueRenamed), useDnMatching == false ? null : new Asn1Boolean(true)), false);
             AddObject(current);
         }

--- a/src/Novell.Directory.Ldap.NETStandard/Rfc2251/RfcModifyDNRequest.cs
+++ b/src/Novell.Directory.Ldap.NETStandard/Rfc2251/RfcModifyDNRequest.cs
@@ -79,7 +79,7 @@ namespace Novell.Directory.Ldap.Rfc2251
             : base(origRequest, origRequest.Length)
         {
             // Replace the base if specified, otherwise keep original base
-            if ((object)baseRenamed != null)
+            if (baseRenamed != null)
             {
                 set_Renamed(0, new RfcLdapDn(baseRenamed));
             }

--- a/src/Novell.Directory.Ldap.NETStandard/Rfc2251/RfcModifyRequest.cs
+++ b/src/Novell.Directory.Ldap.NETStandard/Rfc2251/RfcModifyRequest.cs
@@ -69,7 +69,7 @@ namespace Novell.Directory.Ldap.Rfc2251
             : base(origRequest, origRequest.Length)
         {
             // Replace the base if specified, otherwise keep original base
-            if ((object)baseRenamed != null)
+            if (baseRenamed != null)
             {
                 set_Renamed(0, new RfcLdapDn(baseRenamed));
             }

--- a/src/Novell.Directory.Ldap.NETStandard/Rfc2251/RfcSearchRequest.cs
+++ b/src/Novell.Directory.Ldap.NETStandard/Rfc2251/RfcSearchRequest.cs
@@ -85,7 +85,7 @@ namespace Novell.Directory.Ldap.Rfc2251
             : base(origRequest, origRequest.Length)
         {
             // Replace the base if specified, otherwise keep original base
-            if ((object)baseRenamed != null)
+            if (baseRenamed != null)
             {
                 set_Renamed(0, new RfcLdapDn(baseRenamed));
             }
@@ -103,7 +103,7 @@ namespace Novell.Directory.Ldap.Rfc2251
             }
 
             // Replace the filter if specified, otherwise keep original filter
-            if ((object)filter != null)
+            if (filter != null)
             {
                 set_Renamed(6, new RfcFilter(filter));
             }

--- a/src/Novell.Directory.Ldap.NETStandard/RootDseInfo.cs
+++ b/src/Novell.Directory.Ldap.NETStandard/RootDseInfo.cs
@@ -1,0 +1,75 @@
+﻿using System;
+using System.Collections.Generic;
+
+namespace Novell.Directory.Ldap
+{
+    /// <summary>
+    /// The result of calling <see cref="LdapConnectionExtensionMethods.GetRootDseInfo(ILdapConnection)"/>
+    /// </summary>
+    public class RootDseInfo
+    {
+        public string ServerName { get; }
+        public string DefaultNamingContext { get; }
+        public IReadOnlyList<string> NamingContexts { get; }
+        public IReadOnlyList<string> SupportedSaslMechanisms { get; }
+        public IReadOnlyList<string> SupportedCapabilities { get; }
+        public IReadOnlyList<string> SupportedControls { get; }
+        public IReadOnlyList<string> SupportedExtensions { get; }
+        public IReadOnlyList<string> SupportedLDAPPolicies { get; }
+
+        /// <summary>
+        /// All Root DSE Attributes that aren't already part of other properties of this class
+        /// </summary>
+        public IReadOnlyDictionary<string, IReadOnlyList<string>> OtherAttributes { get; }
+
+        public RootDseInfo(LdapEntry rootDseEntry)
+        {
+            var otherAttributes = new Dictionary<string, IReadOnlyList<string>>();
+            foreach (LdapAttribute attr in rootDseEntry.GetAttributeSet())
+            {
+                switch (attr.Name)
+                {
+                    case "serverName":
+                        ServerName = attr.StringValue;
+                        break;
+                    case "defaultNamingContext":
+                        DefaultNamingContext = attr.StringValue;
+                        break;
+                    case "supportedSASLMechanisms":
+                        SupportedSaslMechanisms = attr.StringValueArray;
+                        break;
+                    case "namingContexts":
+                        NamingContexts = attr.StringValueArray;
+                        break;
+                    case "supportedCapabilities":
+                        SupportedCapabilities = attr.StringValueArray;
+                        break;
+                    case "supportedControl":
+                        SupportedControls = attr.StringValueArray;
+                        break;
+                    case "supportedExtension":
+                        SupportedExtensions = attr.StringValueArray;
+                        break;
+                    case "supportedLDAPPolicies":
+                        SupportedLDAPPolicies = attr.StringValueArray;
+                        break;
+                    default:
+                        otherAttributes[attr.Name] = attr.StringValueArray;
+                        break;
+                }
+            }
+
+            OtherAttributes = otherAttributes;
+
+            // Don't want any of those properties be null
+            ServerName = ServerName ?? "";
+            DefaultNamingContext = DefaultNamingContext ?? "";
+            NamingContexts = NamingContexts ?? Array.Empty<string>();
+            SupportedSaslMechanisms = SupportedSaslMechanisms ?? Array.Empty<string>();
+            SupportedCapabilities = SupportedCapabilities ?? Array.Empty<string>();
+            SupportedControls = SupportedControls ?? Array.Empty<string>();
+            SupportedExtensions = SupportedExtensions ?? Array.Empty<string>();
+            SupportedLDAPPolicies = SupportedLDAPPolicies ?? Array.Empty<string>();
+        }
+    }
+}

--- a/src/Novell.Directory.Ldap.NETStandard/Utilclass/AttributeQualifier.cs
+++ b/src/Novell.Directory.Ldap.NETStandard/Utilclass/AttributeQualifier.cs
@@ -45,7 +45,7 @@ namespace Novell.Directory.Ldap.Utilclass
 
         public AttributeQualifier(string name, string[] valueRenamed)
         {
-            if ((object)name == null || valueRenamed == null)
+            if (name == null || valueRenamed == null)
             {
                 throw new ArgumentException("A null name or value " +
                                             "was passed in for a schema definition qualifier");

--- a/src/Novell.Directory.Ldap.NETStandard/Utilclass/Base64.cs
+++ b/src/Novell.Directory.Ldap.NETStandard/Utilclass/Base64.cs
@@ -170,7 +170,7 @@ namespace Novell.Directory.Ldap.Utilclass
             if (len == 0)
             {
                 // No data, return no data.
-                return new StringBuilder(string.Empty).ToString();
+                return string.Empty;
             }
 
             // every three bytes will be encoded into four bytes

--- a/src/Novell.Directory.Ldap.NETStandard/Utilclass/SchemaParser.cs
+++ b/src/Novell.Directory.Ldap.NETStandard/Utilclass/SchemaParser.cs
@@ -113,7 +113,7 @@ namespace Novell.Directory.Ldap.Utilclass
                                         var nameList = new ArrayList();
                                         while (st2.NextToken() == '\'')
                                         {
-                                            if ((object)st2.StringValue != null)
+                                            if (st2.StringValue != null)
                                             {
                                                 nameList.Add(st2.StringValue);
                                             }


### PR DESCRIPTION
This adds an extension method to ILdapConnection, `GetRootDseInfo`. This is because querying the Root DSE is quite useful for several scenarios, e.g., seeing which SASL Mechanisms are supported, whether StartTLS is supported (supportedExtension contains 1.3.6.1.4.1.1466.20037) etc. This is an extension method to not bloat the Interface or LdapConnection class too much, as this is just a specialized Search Request.

It also cleans up a bunch of Java-isms: `new StringBuilder("...").ToString();` and `(object)someString != null` are clearly something to work around how Java checks strings for equality that we don't need in .net.

There's another big string cleanup that needs to be done, equality checks like `st2.StringValue.ToUpper().Equals("NAME".ToUpper())` are just nasty. But that would result in another huge PR, so I'll do that separately.

Here's an example of the stuff in the Root DSE, in this case for an Active Directory DC:

![image](https://user-images.githubusercontent.com/104127/44267342-d22fa080-a1fb-11e8-84b3-d36ac23325c5.png)
