### PR TITLE
Remove Encoding.GetEncoding("utf-8") and [CLSCompliant]

### DIFF
--- a/src/Novell.Directory.Ldap.NETStandard/Asn1/Asn1Boolean.cs
+++ b/src/Novell.Directory.Ldap.NETStandard/Asn1/Asn1Boolean.cs
@@ -36,7 +36,6 @@ using System.IO;
 namespace Novell.Directory.Ldap.Asn1
 {
     /// <summary> This class encapsulates the ASN.1 BOOLEAN type.</summary>
-    [CLSCompliant(true)]
     public class Asn1Boolean : Asn1Object
     {
         /// <summary> ASN.1 BOOLEAN tag definition.</summary>
@@ -80,7 +79,6 @@ namespace Novell.Directory.Ldap.Asn1
         /// <param name="in">
         ///     A byte stream that contains the encoded ASN.1.
         /// </param>
-        [CLSCompliant(false)]
         public Asn1Boolean(IAsn1Decoder dec, Stream inRenamed, int len)
             : base(Id)
         {

--- a/src/Novell.Directory.Ldap.NETStandard/Asn1/Asn1Choice.cs
+++ b/src/Novell.Directory.Ldap.NETStandard/Asn1/Asn1Choice.cs
@@ -41,7 +41,6 @@ namespace Novell.Directory.Ldap.Asn1
     /// </summary>
     /* Can a CHOICE contain anything BUT a TAGGED Type?
     */
-    [CLSCompliant(true)]
     public class Asn1Choice : Asn1Object
     {
         /* Constructors for Asn1Choice
@@ -79,7 +78,6 @@ namespace Novell.Directory.Ldap.Asn1
         ///     encode.  Since all Asn1 objects are derived from Asn1Object
         ///     any basic type can be passed in.
         /// </param>
-        [CLSCompliant(false)]
         protected Asn1Object ChoiceValue { set; get; }
 
         /* Asn1Object implementation

--- a/src/Novell.Directory.Ldap.NETStandard/Asn1/Asn1Decoder.cs
+++ b/src/Novell.Directory.Ldap.NETStandard/Asn1/Asn1Decoder.cs
@@ -48,7 +48,6 @@ namespace Novell.Directory.Ldap.Asn1
     ///     includes a BER decoder no application provided decoder is needed for
     ///     building Ldap packets.
     /// </summary>
-    [CLSCompliant(false)]
     public interface IAsn1Decoder
     {
         /// <summary>

--- a/src/Novell.Directory.Ldap.NETStandard/Asn1/Asn1Encoder.cs
+++ b/src/Novell.Directory.Ldap.NETStandard/Asn1/Asn1Encoder.cs
@@ -48,7 +48,6 @@ namespace Novell.Directory.Ldap.Asn1
     ///     includes a BER encoder no application provided encoder is needed for
     ///     building Ldap packets.
     /// </summary>
-    [CLSCompliant(true)]
     public interface IAsn1Encoder
     {
         /* Encoders for ASN.1 simple types */

--- a/src/Novell.Directory.Ldap.NETStandard/Asn1/Asn1Enumerated.cs
+++ b/src/Novell.Directory.Ldap.NETStandard/Asn1/Asn1Enumerated.cs
@@ -36,7 +36,6 @@ using System.IO;
 namespace Novell.Directory.Ldap.Asn1
 {
     /// <summary> This class encapsulates the ASN.1 ENUMERATED type.</summary>
-    [CLSCompliant(true)]
     public class Asn1Enumerated : Asn1Numeric
     {
         /// <summary> ASN.1 tag definition for ENUMERATED.</summary>
@@ -90,7 +89,6 @@ namespace Novell.Directory.Ldap.Asn1
         /// <param name="in">
         ///     A byte stream that contains the encoded ASN.1.
         /// </param>
-        [CLSCompliant(false)]
         public Asn1Enumerated(IAsn1Decoder dec, Stream inRenamed, int len)
             : base(Id, (long)dec.DecodeNumeric(inRenamed, len))
         {

--- a/src/Novell.Directory.Ldap.NETStandard/Asn1/Asn1Identifier.cs
+++ b/src/Novell.Directory.Ldap.NETStandard/Asn1/Asn1Identifier.cs
@@ -69,7 +69,6 @@ namespace Novell.Directory.Ldap.Asn1
     ///         1 1 1 1 1 (> 30) multiple octet tag, more octets follow
     ///     </pre>
     /// </summary>
-    [CLSCompliant(true)]
     public class Asn1Identifier : object
     {
         /// <summary>
@@ -185,7 +184,6 @@ namespace Novell.Directory.Ldap.Asn1
         /// </summary>
         /// <seealso cref="Universal">
         /// </seealso>
-        [CLSCompliant(false)]
         public bool IsUniversal => Asn1Class == Universal;
 
         /// <summary>
@@ -194,7 +192,6 @@ namespace Novell.Directory.Ldap.Asn1
         /// </summary>
         /// <seealso cref="Application">
         /// </seealso>
-        [CLSCompliant(false)]
         public bool IsApplication => Asn1Class == Application;
 
         /// <summary>
@@ -203,7 +200,6 @@ namespace Novell.Directory.Ldap.Asn1
         /// </summary>
         /// <seealso cref="Context">
         /// </seealso>
-        [CLSCompliant(false)]
         public bool IsContext => Asn1Class == Context;
 
         /// <summary>
@@ -211,7 +207,6 @@ namespace Novell.Directory.Ldap.Asn1
         ///     has a TAG CLASS of PRIVATE.
         /// </summary>
         /// <seealso cref="Private"></seealso>
-        [CLSCompliant(false)]
         public bool IsPrivate => Asn1Class == Private;
 
         /// <summary>

--- a/src/Novell.Directory.Ldap.NETStandard/Asn1/Asn1Integer.cs
+++ b/src/Novell.Directory.Ldap.NETStandard/Asn1/Asn1Integer.cs
@@ -36,7 +36,6 @@ using System.IO;
 namespace Novell.Directory.Ldap.Asn1
 {
     /// <summary> This class encapsulates the ASN.1 INTEGER type.</summary>
-    [CLSCompliant(true)]
     public class Asn1Integer : Asn1Numeric
     {
         /// <summary> ASN.1 INTEGER tag definition.</summary>
@@ -90,7 +89,6 @@ namespace Novell.Directory.Ldap.Asn1
         /// <param name="in">
         ///     A byte stream that contains the encoded ASN.1.
         /// </param>
-        [CLSCompliant(false)]
         public Asn1Integer(IAsn1Decoder dec, Stream inRenamed, int len)
             : base(Id, (long)dec.DecodeNumeric(inRenamed, len))
         {

--- a/src/Novell.Directory.Ldap.NETStandard/Asn1/Asn1Length.cs
+++ b/src/Novell.Directory.Ldap.NETStandard/Asn1/Asn1Length.cs
@@ -39,7 +39,6 @@ namespace Novell.Directory.Ldap.Asn1
     ///     This class provides a means to manipulate ASN.1 Length's. It will
     ///     be used by Asn1Encoder's and Asn1Decoder's by composition.
     /// </summary>
-    [CLSCompliant(true)]
     public class Asn1Length
     {
         /* Private variables

--- a/src/Novell.Directory.Ldap.NETStandard/Asn1/Asn1Null.cs
+++ b/src/Novell.Directory.Ldap.NETStandard/Asn1/Asn1Null.cs
@@ -36,7 +36,6 @@ using System.IO;
 namespace Novell.Directory.Ldap.Asn1
 {
     /// <summary> This class represents the ASN.1 NULL type.</summary>
-    [CLSCompliant(true)]
     public class Asn1Null : Asn1Object
     {
         /// <summary> ASN.1 NULL tag definition.</summary>

--- a/src/Novell.Directory.Ldap.NETStandard/Asn1/Asn1Numeric.cs
+++ b/src/Novell.Directory.Ldap.NETStandard/Asn1/Asn1Numeric.cs
@@ -39,7 +39,6 @@ namespace Novell.Directory.Ldap.Asn1
     ///     for all Asn1 numeric (integral) types. These include
     ///     Asn1Integer and Asn1Enumerated.
     /// </summary>
-    [CLSCompliant(true)]
     public abstract class Asn1Numeric : Asn1Object
     {
         private readonly long _content;

--- a/src/Novell.Directory.Ldap.NETStandard/Asn1/Asn1Object.cs
+++ b/src/Novell.Directory.Ldap.NETStandard/Asn1/Asn1Object.cs
@@ -37,7 +37,6 @@ using System.Text;
 namespace Novell.Directory.Ldap.Asn1
 {
     /// <summary> This is the base class for all other Asn1 types.</summary>
-    [CLSCompliant(true)]
     public abstract class Asn1Object
     {
         private Asn1Identifier _id;
@@ -87,7 +86,6 @@ namespace Novell.Directory.Ldap.Asn1
         ///     defined in Asn1Object but will usually be implemented
         ///     in the child Asn1 classses.
         /// </summary>
-        [CLSCompliant(false)]
         public byte[] GetEncoding(IAsn1Encoder enc)
         {
             var outRenamed = new MemoryStream();
@@ -106,7 +104,6 @@ namespace Novell.Directory.Ldap.Asn1
         }
 
         /// <summary> Return a String representation of this Asn1Object.</summary>
-        [CLSCompliant(false)]
         public override string ToString()
         {
             string[] classTypes = {"[UNIVERSAL ", "[APPLICATION ", "[", "[PRIVATE " };

--- a/src/Novell.Directory.Ldap.NETStandard/Asn1/Asn1OctetString.cs
+++ b/src/Novell.Directory.Ldap.NETStandard/Asn1/Asn1OctetString.cs
@@ -83,18 +83,8 @@ namespace Novell.Directory.Ldap.Asn1
         {
             try
             {
-/*                System.Text.UTF8Encoding utf8 = new System.Text.UTF8Encoding();
-                byte[] bytes = utf8.GetBytes (content);
-                byte[] sbytes = new byte[bytes.Length+1]; //signed bytes
-                sbytes[0] = 0; //set sign byte to zero.
-                for(int i=1; i<sbytes.Length; i++)
-                    sbytes[i] = (byte) bytes[i-1]; //cast byte-->byte
-*/
-                var encoder = Encoding.GetEncoding("utf-8");
-                var ibytes = encoder.GetBytes(content);
+                var ibytes = content.ToUtf8Bytes();
                 _content = ibytes;
-
-// this.content = content.getBytes("UTF8");
             }
             catch (IOException uee)
             {
@@ -156,15 +146,11 @@ namespace Novell.Directory.Ldap.Asn1
             string s = null;
             try
             {
-                var encoder = Encoding.GetEncoding("utf-8");
-                var dchar = encoder.GetChars(_content);
-                s = new string(dchar);
-
-// byte *sb=content;
-// s = new  String(sb,0,content.Length, new System.Text.UTF8Encoding());
+                s = _content.ToUtf8String();
             }
             catch (IOException uee)
             {
+                // TODO: Why? Just remove the try..catch?
                 throw new Exception(uee.ToString());
             }
 

--- a/src/Novell.Directory.Ldap.NETStandard/Asn1/Asn1OctetString.cs
+++ b/src/Novell.Directory.Ldap.NETStandard/Asn1/Asn1OctetString.cs
@@ -37,7 +37,6 @@ using System.Text;
 namespace Novell.Directory.Ldap.Asn1
 {
     /// <summary> This class encapsulates the OCTET STRING type.</summary>
-    [CLSCompliant(true)]
     public class Asn1OctetString : Asn1Object
     {
         /// <summary> ASN.1 OCTET STRING tag definition.</summary>
@@ -63,7 +62,6 @@ namespace Novell.Directory.Ldap.Asn1
         ///     A byte array representing the string that
         ///     will be contained in the this Asn1OctetString object.
         /// </param>
-        [CLSCompliant(false)]
         public Asn1OctetString(byte[] content)
             : base(Id)
         {
@@ -104,7 +102,6 @@ namespace Novell.Directory.Ldap.Asn1
         /// <param name="in">
         ///     A byte stream that contains the encoded ASN.1.
         /// </param>
-        [CLSCompliant(false)]
         public Asn1OctetString(IAsn1Decoder dec, Stream inRenamed, int len)
             : base(Id)
         {
@@ -134,7 +131,6 @@ namespace Novell.Directory.Ldap.Asn1
         */
 
         /// <summary> Returns the content of this Asn1OctetString as a byte array.</summary>
-        [CLSCompliant(false)]
         public byte[] ByteValue()
         {
             return _content;

--- a/src/Novell.Directory.Ldap.NETStandard/Asn1/Asn1Sequence.cs
+++ b/src/Novell.Directory.Ldap.NETStandard/Asn1/Asn1Sequence.cs
@@ -41,7 +41,6 @@ namespace Novell.Directory.Ldap.Asn1
     ///     This class inherits from the Asn1Structured class which
     ///     provides functionality to hold multiple Asn1 components.
     /// </summary>
-    [CLSCompliant(true)]
     public class Asn1Sequence : Asn1Structured
     {
         /// <summary> ASN.1 SEQUENCE tag definition.</summary>
@@ -106,7 +105,6 @@ namespace Novell.Directory.Ldap.Asn1
         /// <param name="in">
         ///     A byte stream that contains the encoded ASN.1.
         /// </param>
-        [CLSCompliant(false)]
         public Asn1Sequence(IAsn1Decoder dec, Stream inRenamed, int len)
             : base(Id)
         {
@@ -117,7 +115,6 @@ namespace Novell.Directory.Ldap.Asn1
         */
 
         /// <summary> Return a String representation of this Asn1Sequence.</summary>
-        [CLSCompliant(false)]
         public override string ToString()
         {
             return ToString("SEQUENCE: { ");

--- a/src/Novell.Directory.Ldap.NETStandard/Asn1/Asn1SequenceOf.cs
+++ b/src/Novell.Directory.Ldap.NETStandard/Asn1/Asn1SequenceOf.cs
@@ -41,7 +41,6 @@ namespace Novell.Directory.Ldap.Asn1
     ///     from the Asn1Structured class which already provides
     ///     functionality to hold multiple Asn1 components.
     /// </summary>
-    [CLSCompliant(true)]
     public class Asn1SequenceOf : Asn1Structured
     {
         /// <summary> ASN.1 SEQUENCE OF tag definition.</summary>
@@ -105,7 +104,6 @@ namespace Novell.Directory.Ldap.Asn1
         /// <param name="in">
         ///     A byte stream that contains the encoded ASN.1.
         /// </param>
-        [CLSCompliant(false)]
         public Asn1SequenceOf(IAsn1Decoder dec, Stream inRenamed, int len)
             : base(Id)
         {
@@ -116,7 +114,6 @@ namespace Novell.Directory.Ldap.Asn1
         */
 
         /// <summary> Returns a String representation of this Asn1SequenceOf object.</summary>
-        [CLSCompliant(false)]
         public override string ToString()
         {
             return ToString("SEQUENCE OF: { ");

--- a/src/Novell.Directory.Ldap.NETStandard/Asn1/Asn1Set.cs
+++ b/src/Novell.Directory.Ldap.NETStandard/Asn1/Asn1Set.cs
@@ -40,7 +40,6 @@ namespace Novell.Directory.Ldap.Asn1
     ///     distinct type. This class inherits from the Asn1Structured class
     ///     which already provides functionality to hold multiple Asn1 components.
     /// </summary>
-    [CLSCompliant(true)]
     public class Asn1Set : Asn1Structured
     {
         /// <summary> ASN.1 SET tag definition.</summary>
@@ -90,7 +89,6 @@ namespace Novell.Directory.Ldap.Asn1
         /// <param name="in">
         ///     A byte stream that contains the encoded ASN.1.
         /// </param>
-        [CLSCompliant(false)]
         public Asn1Set(IAsn1Decoder dec, Stream inRenamed, int len)
             : base(Id)
         {
@@ -101,7 +99,6 @@ namespace Novell.Directory.Ldap.Asn1
         */
 
         /// <summary> Returns a String representation of this Asn1Set.</summary>
-        [CLSCompliant(false)]
         public override string ToString()
         {
             return ToString("SET: { ");

--- a/src/Novell.Directory.Ldap.NETStandard/Asn1/Asn1SetOf.cs
+++ b/src/Novell.Directory.Ldap.NETStandard/Asn1/Asn1SetOf.cs
@@ -39,7 +39,6 @@ namespace Novell.Directory.Ldap.Asn1
     ///     identical type. This class inherits from the Asn1Structured class
     ///     which already provides functionality to hold multiple Asn1 components.
     /// </summary>
-    [CLSCompliant(true)]
     public class Asn1SetOf : Asn1Structured
     {
         /// <summary> ASN.1 SET OF tag definition.</summary>
@@ -94,7 +93,6 @@ namespace Novell.Directory.Ldap.Asn1
         */
 
         /// <summary> Return a String representation of this Asn1SetOf.</summary>
-        [CLSCompliant(false)]
         public override string ToString()
         {
             return ToString("SET OF: { ");

--- a/src/Novell.Directory.Ldap.NETStandard/Asn1/Asn1Structured.cs
+++ b/src/Novell.Directory.Ldap.NETStandard/Asn1/Asn1Structured.cs
@@ -40,7 +40,6 @@ namespace Novell.Directory.Ldap.Asn1
     ///     This class serves as the base type for all ASN.1
     ///     structured types.
     /// </summary>
-    [CLSCompliant(true)]
     public abstract class Asn1Structured : Asn1Object
     {
         private Asn1Object[] _content;
@@ -99,7 +98,6 @@ namespace Novell.Directory.Ldap.Asn1
         }
 
         /// <summary> Decode an Asn1Structured type from an InputStream.</summary>
-        [CLSCompliant(false)]
         protected internal void DecodeStructured(IAsn1Decoder dec, Stream inRenamed, int len)
         {
             var componentLen = new int[1]; // collects length of component
@@ -205,7 +203,6 @@ namespace Novell.Directory.Ldap.Asn1
         /// <returns>
         ///     the String representation of this object.
         /// </returns>
-        [CLSCompliant(false)]
         public string ToString(string type)
         {
             var sb = new StringBuilder();

--- a/src/Novell.Directory.Ldap.NETStandard/Asn1/Asn1Tagged.cs
+++ b/src/Novell.Directory.Ldap.NETStandard/Asn1/Asn1Tagged.cs
@@ -46,7 +46,6 @@ namespace Novell.Directory.Ldap.Asn1
     ///     If the type is to be encoded EXPLICITLY, the base type will be encoded as
     ///     usual after the Asn1Tagged identifier has been encoded.
     /// </summary>
-    [CLSCompliant(true)]
     public class Asn1Tagged : Asn1Object
     {
         private Asn1Object _content;
@@ -90,7 +89,6 @@ namespace Novell.Directory.Ldap.Asn1
         /// <param name="in">
         ///     A byte stream that contains the encoded ASN.1.
         /// </param>
-        [CLSCompliant(false)]
         public Asn1Tagged(IAsn1Decoder dec, Stream inRenamed, int len, Asn1Identifier identifier)
             : base(identifier)
         {
@@ -102,7 +100,6 @@ namespace Novell.Directory.Ldap.Asn1
         }
 
         /// <summary> Sets the Asn1Object tagged value.</summary>
-        [CLSCompliant(false)]
         public Asn1Object TaggedValue
         {
             set

--- a/src/Novell.Directory.Ldap.NETStandard/Asn1/LBERDecoder.cs
+++ b/src/Novell.Directory.Ldap.NETStandard/Asn1/LBERDecoder.cs
@@ -64,7 +64,6 @@ namespace Novell.Directory.Ldap.Asn1
     ///     [11] ITU-T Rec. X.690, "Specification of ASN.1 encoding rules: Basic,
     ///     Canonical, and Distinguished Encoding Rules", 1994.
     /// </summary>
-    [CLSCompliant(true)]
     public class LberDecoder : IAsn1Decoder
     {
         // used to speed up decode, so it doesn't need to recreate an identifier every time
@@ -81,7 +80,6 @@ namespace Novell.Directory.Ldap.Asn1
         */
 
         /// <summary> Decode an LBER encoded value into an Asn1Type from a byte array.</summary>
-        [CLSCompliant(false)]
         public Asn1Object Decode(byte[] valueRenamed)
         {
             Asn1Object asn1 = null;

--- a/src/Novell.Directory.Ldap.NETStandard/Asn1/LBERDecoder.cs
+++ b/src/Novell.Directory.Ldap.NETStandard/Asn1/LBERDecoder.cs
@@ -265,9 +265,7 @@ namespace Novell.Directory.Ldap.Asn1
                 octets[i] = (byte)ret;
             }
 
-            var encoder = Encoding.GetEncoding("utf-8");
-            var dchar = encoder.GetChars(octets);
-            var rval = new string(dchar);
+            var rval = octets.ToUtf8String();
 
             return rval; // new String( "UTF8");
         }

--- a/src/Novell.Directory.Ldap.NETStandard/Asn1/LBEREncoder.cs
+++ b/src/Novell.Directory.Ldap.NETStandard/Asn1/LBEREncoder.cs
@@ -63,7 +63,6 @@ namespace Novell.Directory.Ldap.Asn1
     ///     [11] ITU-T Rec. X.690, "Specification of ASN.1 encoding rules: Basic,
     ///     Canonical, and Distinguished Encoding Rules", 1994.
     /// </summary>
-    [CLSCompliant(true)]
     public class LberEncoder : IAsn1Encoder
     {
         /* Encoders for ASN.1 simple type Contents

--- a/src/Novell.Directory.Ldap.NETStandard/Connection.cs
+++ b/src/Novell.Directory.Ldap.NETStandard/Connection.cs
@@ -148,7 +148,7 @@ namespace Novell.Directory.Ldap
 
         static Connection()
         {
-            Sdk = new StringBuilder("2.2.1").ToString();
+            Sdk = "2.2.1";
             Protocol = 3;
         }
 

--- a/src/Novell.Directory.Ldap.NETStandard/Connection.cs
+++ b/src/Novell.Directory.Ldap.NETStandard/Connection.cs
@@ -723,7 +723,7 @@ namespace Novell.Directory.Ldap
             _messages.Add(info);
 
             // For bind requests, if not connected, attempt to reconnect
-            if (info.BindRequest && Connected == false && (object)Host != null)
+            if (info.BindRequest && Connected == false && Host != null)
             {
                 Connect(Host, Port, info.MessageId);
             }

--- a/src/Novell.Directory.Ldap.NETStandard/Controls/LdapEntryChangeControl.cs
+++ b/src/Novell.Directory.Ldap.NETStandard/Controls/LdapEntryChangeControl.cs
@@ -72,7 +72,6 @@ namespace Novell.Directory.Ldap.Controls
         /// <param name="value">
         ///     The control-specific data.
         /// </param>
-        [CLSCompliant(false)]
         public LdapEntryChangeControl(string oid, bool critical, byte[] valueRenamed)
             : base(oid, critical, valueRenamed)
         {

--- a/src/Novell.Directory.Ldap.NETStandard/Controls/LdapSortControl.cs
+++ b/src/Novell.Directory.Ldap.NETStandard/Controls/LdapSortControl.cs
@@ -114,7 +114,7 @@ namespace Novell.Directory.Ldap.Controls
 
                 key.Add(new Asn1OctetString(keys[i].Key));
 
-                if ((object)keys[i].MatchRule != null)
+                if (keys[i].MatchRule != null)
                 {
                     key.Add(new Asn1Tagged(
                         new Asn1Identifier(Asn1Identifier.Context, false, OrderingRule),

--- a/src/Novell.Directory.Ldap.NETStandard/Controls/LdapSortResponse.cs
+++ b/src/Novell.Directory.Ldap.NETStandard/Controls/LdapSortResponse.cs
@@ -87,7 +87,6 @@ namespace Novell.Directory.Ldap.Controls
         /// <param name="values">
         ///     The control-specific data.
         /// </param>
-        [CLSCompliant(false)]
         public LdapSortResponse(string oid, bool critical, byte[] values)
             : base(oid, critical, values)
         {

--- a/src/Novell.Directory.Ldap.NETStandard/Controls/LdapVirtualListControl.cs
+++ b/src/Novell.Directory.Ldap.NETStandard/Controls/LdapVirtualListControl.cs
@@ -382,7 +382,7 @@ namespace Novell.Directory.Ldap.Controls
 
             /* Add the optional context string if one is available.
             */
-            if ((object)_mContext != null)
+            if (_mContext != null)
             {
                 _mVlvRequest.Add(new Asn1OctetString(_mContext));
             }
@@ -417,7 +417,7 @@ namespace Novell.Directory.Ldap.Controls
 
             /* Add the optional context string if one is available.
             */
-            if ((object)_mContext != null)
+            if (_mContext != null)
             {
                 _mVlvRequest.Add(new Asn1OctetString(_mContext));
             }

--- a/src/Novell.Directory.Ldap.NETStandard/Controls/LdapVirtualListResponse.cs
+++ b/src/Novell.Directory.Ldap.NETStandard/Controls/LdapVirtualListResponse.cs
@@ -93,7 +93,6 @@ namespace Novell.Directory.Ldap.Controls
         /// <param name="values">
         ///     The control-specific data.
         /// </param>
-        [CLSCompliant(false)]
         public LdapVirtualListResponse(string oid, bool critical, byte[] values)
             : base(oid, critical, values)
         {

--- a/src/Novell.Directory.Ldap.NETStandard/ExtensionMethods.cs
+++ b/src/Novell.Directory.Ldap.NETStandard/ExtensionMethods.cs
@@ -38,7 +38,7 @@ namespace Novell.Directory.Ldap
         /// Shortcut for <see cref="UTF8Encoding.GetString"/>
         /// Will return an empty string if <paramref name="input"/> is null or empty.
         /// </summary>
-        internal static string FromUtf8Bytes(this byte[] input)
+        internal static string ToUtf8String(this byte[] input)
             => input.IsNotEmpty() ? Encoding.UTF8.GetString(input) : string.Empty;
 
         /// <summary>

--- a/src/Novell.Directory.Ldap.NETStandard/ExtensionMethods.cs
+++ b/src/Novell.Directory.Ldap.NETStandard/ExtensionMethods.cs
@@ -1,10 +1,21 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Text;
 
 namespace Novell.Directory.Ldap
 {
     internal static partial class ExtensionMethods
     {
+        /// <summary>
+        /// Shortcut for <see cref="string.IsNullOrEmpty"/>
+        /// </summary>
+        internal static bool IsEmpty(this string input) => string.IsNullOrEmpty(input);
+
+        /// <summary>
+        /// Shortcut for negative <see cref="string.IsNullOrEmpty"/>
+        /// </summary>
+        internal static bool IsNotEmpty(this string input) => !IsEmpty(input);
+
         /// <summary>
         /// Is the given collection null, or Empty (0 elements)?
         /// </summary>
@@ -19,8 +30,25 @@ namespace Novell.Directory.Ldap
         internal static bool IsNotEmpty<T>(this IReadOnlyCollection<T> coll) => !IsEmpty(coll);
 
         /// <summary>
-        /// Shortcut for Encoding.UTF8.GetBytes
+        /// Shortcut for <see cref="UTF8Encoding.GetBytes"/>
         /// </summary>
         internal static byte[] ToUtf8Bytes(this string input) => Encoding.UTF8.GetBytes(input);
+
+        /// <summary>
+        /// Shortcut for <see cref="UTF8Encoding.GetString"/>
+        /// Will return an empty string if <paramref name="input"/> is null or empty.
+        /// </summary>
+        internal static string FromUtf8Bytes(this byte[] input)
+            => input.IsNotEmpty() ? Encoding.UTF8.GetString(input) : string.Empty;
+
+        /// <summary>
+        /// Compare two strings using <see cref="StringComparison.Ordinal"/>
+        /// </summary>
+        internal static bool EqualsOrdinal(this string input, string other) => string.Equals(input, other, StringComparison.Ordinal);
+
+        /// <summary>
+        /// Compare two strings using <see cref="StringComparison.OrdinalIgnoreCase"/>
+        /// </summary>
+        internal static bool EqualsOrdinalCI(this string input, string other) => string.Equals(input, other, StringComparison.OrdinalIgnoreCase);
     }
 }

--- a/src/Novell.Directory.Ldap.NETStandard/ILdapConnection.ExtensionMethods.cs
+++ b/src/Novell.Directory.Ldap.NETStandard/ILdapConnection.ExtensionMethods.cs
@@ -1,0 +1,25 @@
+﻿namespace Novell.Directory.Ldap
+{
+    /// <summary>
+    /// Extension Methods for <see cref="ILdapConnection"/> to
+    /// avoid bloating that interface.
+    /// </summary>
+    public static class LdapConnectionExtensionMethods
+    {
+        /// <summary>
+        /// Get some common Attributes from the Root DSE.
+        /// This is really just a specialized <see cref="LdapSearchRequest"/>
+        /// to handle getting some commonly requested information.
+        /// </summary>
+        public static RootDseInfo GetRootDseInfo(this ILdapConnection conn)
+        {
+            var searchResults = conn.Search("", LdapConnection.ScopeBase, "(objectClass=*)", new string[] { "*", "supportedExtension" }, false);
+            if (searchResults.HasMore())
+            {
+                var sr = searchResults.Next();
+                return new RootDseInfo(sr);
+            }
+            return null;
+        }
+    }
+}

--- a/src/Novell.Directory.Ldap.NETStandard/LdapAttribute.cs
+++ b/src/Novell.Directory.Ldap.NETStandard/LdapAttribute.cs
@@ -157,9 +157,7 @@ namespace Novell.Directory.Ldap
 
             try
             {
-                var encoder = Encoding.GetEncoding("utf-8");
-                var ibytes = encoder.GetBytes(attrString);
-
+                var ibytes = attrString.ToUtf8Bytes();
                 Add(ibytes);
             }
             catch (IOException e)
@@ -196,11 +194,8 @@ namespace Novell.Directory.Ldap
                         throw new ArgumentException("Attribute value " + "at array index " + i + " cannot be null");
                     }
 
-                    var encoder = Encoding.GetEncoding("utf-8");
-                    var ibytes = encoder.GetBytes(attrStrings[i]);
+                    var ibytes = attrStrings[i].ToUtf8Bytes();
                     Add(ibytes);
-
-// this.add(attrStrings[i].getBytes("UTF-8"));
                 }
                 catch (IOException e)
                 {
@@ -280,13 +275,8 @@ namespace Novell.Directory.Ldap
                 {
                     try
                     {
-                        var encoder = Encoding.GetEncoding("utf-8");
-                        var dchar = encoder.GetChars((byte[])_values[j]);
-
-// char[] dchar = encoder.GetChars((byte[])values[j]);
-                        sva[j] = new string(dchar);
-
-// sva[j] = new String((byte[]) values[j], "UTF-8");
+                        var valueBytes = (byte[])_values[j];
+                        sva[j] = valueBytes.ToUtf8String();
                     }
                     catch (IOException uee)
                     {
@@ -323,11 +313,8 @@ namespace Novell.Directory.Ldap
                 {
                     try
                     {
-                        var encoder = Encoding.GetEncoding("utf-8");
-                        var dchar = encoder.GetChars((byte[])_values[0]);
-
-// char[] dchar = encoder.GetChars((byte[]) this.values[0]);
-                        rval = new string(dchar);
+                        var valueBytes = (byte[])_values[0];
+                        rval = valueBytes.ToUtf8String();
                     }
                     catch (IOException use)
                     {
@@ -412,10 +399,7 @@ namespace Novell.Directory.Ldap
                 _values = null;
                 try
                 {
-                    var encoder = Encoding.GetEncoding("utf-8");
-                    var ibytes = encoder.GetBytes(value);
-
-                    Add(ibytes);
+                    Add(value.ToUtf8Bytes());
                 }
                 catch (IOException ue)
                 {
@@ -482,9 +466,7 @@ namespace Novell.Directory.Ldap
 
             try
             {
-                var encoder = Encoding.GetEncoding("utf-8");
-                var ibytes = encoder.GetBytes(attrString);
-                Add(ibytes);
+                Add(attrString.ToUtf8Bytes());
             }
             catch (IOException ue)
             {
@@ -840,11 +822,7 @@ namespace Novell.Directory.Ldap
 
             try
             {
-                var encoder = Encoding.GetEncoding("utf-8");
-                var ibytes = encoder.GetBytes(attrString);
-                RemoveValue(ibytes);
-
-// this.removeValue(attrString.getBytes("UTF-8"));
+                RemoveValue(attrString.ToUtf8Bytes());
             }
             catch (IOException uee)
             {
@@ -1033,18 +1011,14 @@ namespace Novell.Directory.Ldap
                             result.Append("','");
                         }
 
-                        if (((byte[])_values[i]).Length == 0)
+                        var valueBytes = (byte[])_values[i];
+
+                        if (valueBytes.Length == 0)
                         {
                             continue;
                         }
 
-                        var encoder = Encoding.GetEncoding("utf-8");
-
-// char[] dchar = encoder.GetChars((byte[]) values[i]);
-                        var dchar = encoder.GetChars((byte[])_values[i]);
-                        var sval = new string(dchar);
-
-// System.String sval = new String((byte[]) values[i], "UTF-8");
+                        var sval = valueBytes.ToUtf8String();
                         if (sval.Length == 0)
                         {
                             // didn't decode well, must be binary

--- a/src/Novell.Directory.Ldap.NETStandard/LdapAttribute.cs
+++ b/src/Novell.Directory.Ldap.NETStandard/LdapAttribute.cs
@@ -122,7 +122,6 @@ namespace Novell.Directory.Ldap
         ///     Note: If attrBytes represents a string it should be UTF-8 encoded.
         ///     @throws IllegalArgumentException if attrName or attrBytes is null.
         /// </param>
-        [CLSCompliant(false)]
         public LdapAttribute(string attrName, byte[] attrBytes)
             : this(attrName)
         {
@@ -229,7 +228,6 @@ namespace Novell.Directory.Ldap
         ///     The values as an array of bytes or an empty array if there are
         ///     no values.
         /// </returns>
-        [CLSCompliant(false)]
         public byte[][] ByteValueArray
         {
             get
@@ -334,7 +332,6 @@ namespace Novell.Directory.Ldap
         ///     <code>null</code> if. <code>this</code> attribute doesn't have a value.
         ///     If the attribute has no values. <code>null</code> is returned.
         /// </returns>
-        [CLSCompliant(false)]
         public byte[] ByteValue
         {
             get
@@ -482,7 +479,6 @@ namespace Novell.Directory.Ldap
         ///     Note: If attrBytes represents a string it should be UTF-8 encoded.
         ///     @throws IllegalArgumentException if attrBytes is null.
         /// </param>
-        [CLSCompliant(false)]
         public void AddValue(byte[] attrBytes)
         {
             if (attrBytes == null)
@@ -842,7 +838,6 @@ namespace Novell.Directory.Ldap
         ///     no effect.
         ///     @throws IllegalArgumentException if attrBytes is null.
         /// </param>
-        [CLSCompliant(false)]
         public void RemoveValue(byte[] attrBytes)
         {
             if (attrBytes == null)

--- a/src/Novell.Directory.Ldap.NETStandard/LdapAttribute.cs
+++ b/src/Novell.Directory.Ldap.NETStandard/LdapAttribute.cs
@@ -101,7 +101,7 @@ namespace Novell.Directory.Ldap
         /// </param>
         public LdapAttribute(string attrName)
         {
-            if ((object)attrName == null)
+            if (attrName == null)
             {
                 throw new ArgumentException("Attribute name cannot be null");
             }
@@ -150,7 +150,7 @@ namespace Novell.Directory.Ldap
         public LdapAttribute(string attrName, string attrString)
             : this(attrName)
         {
-            if ((object)attrString == null)
+            if (attrString == null)
             {
                 throw new ArgumentException("Attribute value cannot be null");
             }
@@ -191,7 +191,7 @@ namespace Novell.Directory.Ldap
             {
                 try
                 {
-                    if ((object)attrStrings[i] == null)
+                    if (attrStrings[i] == null)
                     {
                         throw new ArgumentException("Attribute value " + "at array index " + i + " cannot be null");
                     }
@@ -475,7 +475,7 @@ namespace Novell.Directory.Ldap
         /// </param>
         public virtual void AddValue(string attrString)
         {
-            if ((object)attrString == null)
+            if (attrString == null)
             {
                 throw new ArgumentException("Attribute value cannot be null");
             }
@@ -522,7 +522,7 @@ namespace Novell.Directory.Ldap
         /// </param>
         public void AddBase64Value(string attrString)
         {
-            if ((object)attrString == null)
+            if (attrString == null)
             {
                 throw new ArgumentException("Attribute value cannot be null");
             }
@@ -586,7 +586,7 @@ namespace Novell.Directory.Ldap
         /// </param>
         public void AddUrlValue(string url)
         {
-            if ((object)url == null)
+            if (url == null)
             {
                 throw new ArgumentException("Attribute URL cannot be null");
             }
@@ -679,7 +679,7 @@ namespace Novell.Directory.Ldap
         /// </returns>
         public static string GetBaseName(string attrName)
         {
-            if ((object)attrName == null)
+            if (attrName == null)
             {
                 throw new ArgumentException("Attribute name cannot be null");
             }
@@ -721,7 +721,7 @@ namespace Novell.Directory.Ldap
         /// </returns>
         public static string[] GetSubtypes(string attrName)
         {
-            if ((object)attrName == null)
+            if (attrName == null)
             {
                 throw new ArgumentException("Attribute name cannot be null");
             }
@@ -758,7 +758,7 @@ namespace Novell.Directory.Ldap
         /// </returns>
         public bool HasSubtype(string subtype)
         {
-            if ((object)subtype == null)
+            if (subtype == null)
             {
                 throw new ArgumentException("subtype cannot be null");
             }
@@ -804,7 +804,7 @@ namespace Novell.Directory.Ldap
             {
                 for (var j = 0; j < _subTypes.Length; j++)
                 {
-                    if ((object)_subTypes[j] == null)
+                    if (_subTypes[j] == null)
                     {
                         throw new ArgumentException("subtype " + "at array index " + i + " cannot be null");
                     }
@@ -833,7 +833,7 @@ namespace Novell.Directory.Ldap
         /// </param>
         public virtual void RemoveValue(string attrString)
         {
-            if ((object)attrString == null)
+            if (attrString == null)
             {
                 throw new ArgumentException("Attribute value cannot be null");
             }

--- a/src/Novell.Directory.Ldap.NETStandard/LdapAttributeSchema.cs
+++ b/src/Novell.Directory.Ldap.NETStandard/LdapAttributeSchema.cs
@@ -173,22 +173,22 @@ namespace Novell.Directory.Ldap
                     names = parser.Names;
                 }
 
-                if ((object)parser.Id != null)
+                if (parser.Id != null)
                 {
                     Oid = parser.Id;
                 }
 
-                if ((object)parser.Description != null)
+                if (parser.Description != null)
                 {
                     Description = parser.Description;
                 }
 
-                if ((object)parser.Syntax != null)
+                if (parser.Syntax != null)
                 {
                     SyntaxString = parser.Syntax;
                 }
 
-                if ((object)parser.Superior != null)
+                if (parser.Superior != null)
                 {
                     Superior = parser.Superior;
                 }
@@ -310,7 +310,7 @@ namespace Novell.Directory.Ldap
             var valueBuffer = new StringBuilder("( ");
             string token;
 
-            if ((object)(token = Id) != null)
+            if ((token = Id) != null)
             {
                 valueBuffer.Append(token);
             }
@@ -336,7 +336,7 @@ namespace Novell.Directory.Ldap
                 }
             }
 
-            if ((object)(token = Description) != null)
+            if ((token = Description) != null)
             {
                 valueBuffer.Append(" DESC ");
                 valueBuffer.Append("'" + token + "'");
@@ -347,31 +347,31 @@ namespace Novell.Directory.Ldap
                 valueBuffer.Append(" OBSOLETE");
             }
 
-            if ((object)(token = Superior) != null)
+            if ((token = Superior) != null)
             {
                 valueBuffer.Append(" SUP ");
                 valueBuffer.Append("'" + token + "'");
             }
 
-            if ((object)(token = EqualityMatchingRule) != null)
+            if ((token = EqualityMatchingRule) != null)
             {
                 valueBuffer.Append(" EQUALITY ");
                 valueBuffer.Append("'" + token + "'");
             }
 
-            if ((object)(token = OrderingMatchingRule) != null)
+            if ((token = OrderingMatchingRule) != null)
             {
                 valueBuffer.Append(" ORDERING ");
                 valueBuffer.Append("'" + token + "'");
             }
 
-            if ((object)(token = SubstringMatchingRule) != null)
+            if ((token = SubstringMatchingRule) != null)
             {
                 valueBuffer.Append(" SUBSTR ");
                 valueBuffer.Append("'" + token + "'");
             }
 
-            if ((object)(token = SyntaxString) != null)
+            if ((token = SyntaxString) != null)
             {
                 valueBuffer.Append(" SYNTAX ");
                 valueBuffer.Append(token);
@@ -419,7 +419,7 @@ namespace Novell.Directory.Ldap
             while (en.MoveNext())
             {
                 token = (string)en.Current;
-                if ((object)token != null)
+                if (token != null)
                 {
                     valueBuffer.Append(" " + token);
                     strArray = GetQualifier(token);

--- a/src/Novell.Directory.Ldap.NETStandard/LdapAttributeSet.cs
+++ b/src/Novell.Directory.Ldap.NETStandard/LdapAttributeSet.cs
@@ -356,7 +356,7 @@ namespace Novell.Directory.Ldap
                 attributeName = ((LdapAttribute)objectRenamed).Name;
             }
 
-            if ((object)attributeName == null)
+            if (attributeName == null)
             {
                 return false;
             }

--- a/src/Novell.Directory.Ldap.NETStandard/LdapAuthProvider.cs
+++ b/src/Novell.Directory.Ldap.NETStandard/LdapAuthProvider.cs
@@ -57,7 +57,6 @@ namespace Novell.Directory.Ldap
         /// <param name="password">
         ///     The password to use when authenticating to a server.
         /// </param>
-        [CLSCompliant(false)]
         public LdapAuthProvider(string dn, byte[] password)
         {
             Dn = dn;
@@ -80,7 +79,6 @@ namespace Novell.Directory.Ldap
         /// <returns>
         ///     The byte[] value (UTF-8) of the password from the object.
         /// </returns>
-        [CLSCompliant(false)]
         public virtual byte[] Password { get; }
     }
 }

--- a/src/Novell.Directory.Ldap.NETStandard/LdapBindRequest.cs
+++ b/src/Novell.Directory.Ldap.NETStandard/LdapBindRequest.cs
@@ -72,7 +72,6 @@ namespace Novell.Directory.Ldap
         ///     Any controls that apply to the simple bind request,
         ///     or null if none.
         /// </param>
-        [CLSCompliant(false)]
         public LdapBindRequest(int version, string dn, byte[] passwd, LdapControl[] cont)
             : base(
                 BindRequest,

--- a/src/Novell.Directory.Ldap.NETStandard/LdapCompareRequest.cs
+++ b/src/Novell.Directory.Ldap.NETStandard/LdapCompareRequest.cs
@@ -64,7 +64,6 @@ namespace Novell.Directory.Ldap
         ///     Any controls that apply to the compare request,
         ///     or null if none.
         /// </param>
-        [CLSCompliant(false)]
         public LdapCompareRequest(string dn, string name, byte[] valueRenamed, LdapControl[] cont)
             : base(
                 CompareRequest,
@@ -97,7 +96,6 @@ namespace Novell.Directory.Ldap
         /// <returns>
         ///     the LdapAttribute.
         /// </returns>
-        [CLSCompliant(false)]
         public byte[] AssertionValue
         {
             get

--- a/src/Novell.Directory.Ldap.NETStandard/LdapConnection.cs
+++ b/src/Novell.Directory.Ldap.NETStandard/LdapConnection.cs
@@ -785,9 +785,7 @@ namespace Novell.Directory.Ldap
             byte[] pw = null;
             if (passwd != null)
             {
-                var encoder = Encoding.GetEncoding("utf-8");
-                var ibytes = encoder.GetBytes(passwd);
-                pw = ibytes;
+                pw = passwd.ToUtf8Bytes();
             }
 
             Bind(version, dn, pw, cons);

--- a/src/Novell.Directory.Ldap.NETStandard/LdapConnection.cs
+++ b/src/Novell.Directory.Ldap.NETStandard/LdapConnection.cs
@@ -819,7 +819,6 @@ namespace Novell.Directory.Ldap
         ///     LdapException A general exception which includes an error
         ///     message and an Ldap error code.
         /// </exception>
-        [CLSCompliant(false)]
         public void Bind(int version, string dn, byte[] passwd)
         {
             Bind(version, dn, passwd, _defSearchCons);
@@ -856,7 +855,6 @@ namespace Novell.Directory.Ldap
         ///     LdapException A general exception which includes an error
         ///     message and an Ldap error code.
         /// </exception>
-        [CLSCompliant(false)]
         public void Bind(int version, string dn, byte[] passwd, LdapConstraints cons)
         {
             var queue = Bind(version, dn, passwd, null, cons);
@@ -1901,7 +1899,6 @@ namespace Novell.Directory.Ldap
         ///     LdapException A general exception which includes an error
         ///     message and an Ldap error code.
         /// </exception>
-        [CLSCompliant(false)]
         public LdapResponseQueue Bind(int version, string dn, byte[] passwd, LdapResponseQueue queue)
         {
             return Bind(version, dn, passwd, queue, _defSearchCons);
@@ -1943,7 +1940,6 @@ namespace Novell.Directory.Ldap
         ///     LdapException A general exception which includes an error
         ///     message and an Ldap error code.
         /// </exception>
-        [CLSCompliant(false)]
         public LdapResponseQueue Bind(int version, string dn, byte[] passwd, LdapResponseQueue queue,
             LdapConstraints cons)
         {

--- a/src/Novell.Directory.Ldap.NETStandard/LdapConnection.cs
+++ b/src/Novell.Directory.Ldap.NETStandard/LdapConnection.cs
@@ -783,7 +783,7 @@ namespace Novell.Directory.Ldap
         public void Bind(int version, string dn, string passwd, LdapConstraints cons)
         {
             byte[] pw = null;
-            if ((object)passwd != null)
+            if (passwd != null)
             {
                 var encoder = Encoding.GetEncoding("utf-8");
                 var ibytes = encoder.GetBytes(passwd);
@@ -1860,7 +1860,7 @@ namespace Novell.Directory.Ldap
                 throw new ArgumentException("The LdapEntry parameter" + " cannot be null");
             }
 
-            if ((object)entry.Dn == null)
+            if (entry.Dn == null)
             {
                 throw new ArgumentException("The DN value must be present" + " in the LdapEntry object");
             }
@@ -1954,7 +1954,7 @@ namespace Novell.Directory.Ldap
                 cons = _defSearchCons;
             }
 
-            if ((object)dn == null)
+            if (dn == null)
             {
                 dn = string.Empty;
             }
@@ -1983,7 +1983,7 @@ namespace Novell.Directory.Ldap
             // For bind requests, if not connected, attempt to reconnect
             if (!Connection.Connected)
             {
-                if ((object)Connection.Host != null)
+                if (Connection.Host != null)
                 {
                     Connection.Connect(Connection.Host, Connection.Port);
                 }
@@ -2159,7 +2159,7 @@ namespace Novell.Directory.Ldap
                 throw new ArgumentException("compare: Exactly one value " + "must be present in the LdapAttribute");
             }
 
-            if ((object)dn == null)
+            if (dn == null)
             {
                 // Invalid parameter
                 throw new ArgumentException("compare: DN cannot be null");
@@ -2221,7 +2221,7 @@ namespace Novell.Directory.Ldap
         /// </exception>
         public LdapResponseQueue Delete(string dn, LdapResponseQueue queue, LdapConstraints cons)
         {
-            if ((object)dn == null)
+            if (dn == null)
             {
                 // Invalid DN parameter
                 throw new ArgumentException(ExceptionMessages.DnParamError);
@@ -2341,7 +2341,7 @@ namespace Novell.Directory.Ldap
             }
 
             // error check the parameters
-            if ((object)op.GetId() == null)
+            if (op.GetId() == null)
             {
                 // Invalid extended operation parameter, no OID specified
                 throw new ArgumentException(ExceptionMessages.OpParamError);
@@ -2479,7 +2479,7 @@ namespace Novell.Directory.Ldap
         public LdapResponseQueue Modify(string dn, LdapModification[] mods, LdapResponseQueue queue,
             LdapConstraints cons)
         {
-            if ((object)dn == null)
+            if (dn == null)
             {
                 // Invalid DN parameter
                 throw new ArgumentException(ExceptionMessages.DnParamError);
@@ -2688,7 +2688,7 @@ namespace Novell.Directory.Ldap
         public LdapResponseQueue Rename(string dn, string newRdn, string newParentdn, bool deleteOldRdn,
             LdapResponseQueue queue, LdapConstraints cons)
         {
-            if ((object)dn == null || (object)newRdn == null)
+            if (dn == null || newRdn == null)
             {
                 // Invalid DN or RDN parameter
                 throw new ArgumentException(ExceptionMessages.RdnParamError);
@@ -2795,7 +2795,7 @@ namespace Novell.Directory.Ldap
         public LdapSearchQueue Search(string @base, int scope, string filter, string[] attrs, bool typesOnly,
             LdapSearchQueue queue, LdapSearchConstraints cons)
         {
-            if ((object)filter == null)
+            if (filter == null)
             {
                 filter = "objectclass=*";
             }

--- a/src/Novell.Directory.Ldap.NETStandard/LdapControl.cs
+++ b/src/Novell.Directory.Ldap.NETStandard/LdapControl.cs
@@ -75,7 +75,7 @@ namespace Novell.Directory.Ldap
         [CLSCompliant(false)]
         public LdapControl(string oid, bool critical, byte[] values)
         {
-            if ((object)oid == null)
+            if (oid == null)
             {
                 throw new ArgumentException("An OID must be specified");
             }

--- a/src/Novell.Directory.Ldap.NETStandard/LdapControl.cs
+++ b/src/Novell.Directory.Ldap.NETStandard/LdapControl.cs
@@ -103,7 +103,7 @@ namespace Novell.Directory.Ldap
         /// <returns>
         ///     The object ID of the control.
         /// </returns>
-        public string Id => new StringBuilder(Asn1Object.ControlType.StringValue()).ToString();
+        public string Id => Asn1Object.ControlType.StringValue();
 
         /// <summary>
         ///     Returns whether the control is critical for the operation.

--- a/src/Novell.Directory.Ldap.NETStandard/LdapControl.cs
+++ b/src/Novell.Directory.Ldap.NETStandard/LdapControl.cs
@@ -72,7 +72,6 @@ namespace Novell.Directory.Ldap
         /// <param name="values">
         ///     The control-specific data.
         /// </param>
-        [CLSCompliant(false)]
         public LdapControl(string oid, bool critical, byte[] values)
         {
             if (oid == null)
@@ -171,7 +170,6 @@ namespace Novell.Directory.Ldap
         ///     The control-specific data of the object as a byte array,
         ///     or null if the control has no data.
         /// </returns>
-        [CLSCompliant(false)]
         public byte[] GetValue()
         {
             byte[] result = null;
@@ -188,7 +186,6 @@ namespace Novell.Directory.Ldap
         ///     Sets the control-specific data of the object.  This method is for
         ///     use by an extension of LdapControl.
         /// </summary>
-        [CLSCompliant(false)]
         protected void SetValue(byte[] controlValue)
         {
             Asn1Object.ControlValue = new Asn1OctetString(controlValue);

--- a/src/Novell.Directory.Ldap.NETStandard/LdapDITContentRuleSchema.cs
+++ b/src/Novell.Directory.Ldap.NETStandard/LdapDITContentRuleSchema.cs
@@ -129,12 +129,12 @@ namespace Novell.Directory.Ldap
                     parser.Names.CopyTo(names, 0);
                 }
 
-                if ((object)parser.Id != null)
+                if (parser.Id != null)
                 {
                     Oid = parser.Id;
                 }
 
-                if ((object)parser.Description != null)
+                if (parser.Description != null)
                 {
                     Description = parser.Description;
                 }
@@ -226,7 +226,7 @@ namespace Novell.Directory.Ldap
             var valueBuffer = new StringBuilder("( ");
             string token;
 
-            if ((object)(token = Id) != null)
+            if ((token = Id) != null)
             {
                 valueBuffer.Append(token);
             }
@@ -252,7 +252,7 @@ namespace Novell.Directory.Ldap
                 }
             }
 
-            if ((object)(token = Description) != null)
+            if ((token = Description) != null)
             {
                 valueBuffer.Append(" DESC ");
                 valueBuffer.Append("'" + token + "'");

--- a/src/Novell.Directory.Ldap.NETStandard/LdapDITStructureRuleSchema.cs
+++ b/src/Novell.Directory.Ldap.NETStandard/LdapDITStructureRuleSchema.cs
@@ -115,12 +115,12 @@ namespace Novell.Directory.Ldap
                     parser.Names.CopyTo(names, 0);
                 }
 
-                if ((object)parser.Id != null)
+                if (parser.Id != null)
                 {
                     RuleId = int.Parse(parser.Id);
                 }
 
-                if ((object)parser.Description != null)
+                if (parser.Description != null)
                 {
                     Description = parser.Description;
                 }
@@ -131,7 +131,7 @@ namespace Novell.Directory.Ldap
                     parser.Superiors.CopyTo(Superiors, 0);
                 }
 
-                if ((object)parser.NameForm != null)
+                if (parser.NameForm != null)
                 {
                     NameForm = parser.NameForm;
                 }
@@ -220,7 +220,7 @@ namespace Novell.Directory.Ldap
                 }
             }
 
-            if ((object)(token = Description) != null)
+            if ((token = Description) != null)
             {
                 valueBuffer.Append(" DESC ");
                 valueBuffer.Append("'" + token + "'");
@@ -231,7 +231,7 @@ namespace Novell.Directory.Ldap
                 valueBuffer.Append(" OBSOLETE");
             }
 
-            if ((object)(token = NameForm) != null)
+            if ((token = NameForm) != null)
             {
                 valueBuffer.Append(" FORM ");
                 valueBuffer.Append("'" + token + "'");

--- a/src/Novell.Directory.Ldap.NETStandard/LdapDN.cs
+++ b/src/Novell.Directory.Ldap.NETStandard/LdapDN.cs
@@ -60,7 +60,6 @@ namespace Novell.Directory.Ldap
         ///     Returns true if the two strings correspond to the same DN; false
         ///     if the DNs are different.
         /// </returns>
-        [CLSCompliant(false)]
         public static bool Equals(string dn1, string dn2)
         {
             var dnA = new Dn(dn1);

--- a/src/Novell.Directory.Ldap.NETStandard/LdapEntry.cs
+++ b/src/Novell.Directory.Ldap.NETStandard/LdapEntry.cs
@@ -86,7 +86,7 @@ namespace Novell.Directory.Ldap
         /// </param>
         public LdapEntry(string dn, LdapAttributeSet attrs)
         {
-            if ((object)dn == null)
+            if (dn == null)
             {
                 dn = string.Empty;
             }

--- a/src/Novell.Directory.Ldap.NETStandard/LdapEntry.cs
+++ b/src/Novell.Directory.Ldap.NETStandard/LdapEntry.cs
@@ -106,7 +106,6 @@ namespace Novell.Directory.Ldap
         /// <returns>
         ///     The distinguished name of the entry.
         /// </returns>
-        [CLSCompliant(false)]
         public string Dn { get; set; }
 
         /// <summary>

--- a/src/Novell.Directory.Ldap.NETStandard/LdapException.cs
+++ b/src/Novell.Directory.Ldap.NETStandard/LdapException.cs
@@ -1116,7 +1116,7 @@ namespace Novell.Directory.Ldap
         {
             get
             {
-                if ((object)_serverMessage != null && _serverMessage.Length == 0)
+                if (_serverMessage != null && _serverMessage.Length == 0)
                 {
                     return null;
                 }
@@ -1264,7 +1264,7 @@ namespace Novell.Directory.Ldap
             }
 
             // Add server message
-            if ((object)_serverMessage != null && _serverMessage.Length != 0)
+            if (!string.IsNullOrEmpty(_serverMessage))
             {
                 tmsg = ResourcesHandler.GetMessage("SERVER_MSG", new object[] {exception, _serverMessage });
 
@@ -1278,7 +1278,7 @@ namespace Novell.Directory.Ldap
             }
 
             // Add Matched DN message
-            if ((object)MatchedDn != null)
+            if (MatchedDn != null)
             {
                 tmsg = ResourcesHandler.GetMessage("MATCHED_DN", new object[] {exception, MatchedDn });
 

--- a/src/Novell.Directory.Ldap.NETStandard/LdapExtendedOperation.cs
+++ b/src/Novell.Directory.Ldap.NETStandard/LdapExtendedOperation.cs
@@ -55,7 +55,6 @@ namespace Novell.Directory.Ldap
         /// <param name="vals">
         ///     The operation-specific data of the operation.
         /// </param>
-        [CLSCompliant(false)]
         public LdapExtendedOperation(string oid, byte[] vals)
         {
             _oid = oid;
@@ -101,7 +100,6 @@ namespace Novell.Directory.Ldap
         /// <returns>
         ///     The operation-specific data.
         /// </returns>
-        [CLSCompliant(false)]
         public byte[] GetValue()
         {
             return _vals;
@@ -113,7 +111,6 @@ namespace Novell.Directory.Ldap
         /// <param name="newVals">
         ///     The byte array of operation-specific data.
         /// </param>
-        [CLSCompliant(false)]
         protected void SetValue(byte[] newVals)
         {
             _vals = newVals;

--- a/src/Novell.Directory.Ldap.NETStandard/LdapExtendedResponse.cs
+++ b/src/Novell.Directory.Ldap.NETStandard/LdapExtendedResponse.cs
@@ -85,7 +85,6 @@ namespace Novell.Directory.Ldap
         /// <returns>
         ///     The value of the response.
         /// </returns>
-        [CLSCompliant(false)]
         public byte[] Value
         {
             get

--- a/src/Novell.Directory.Ldap.NETStandard/LdapIntermediateResponse.cs
+++ b/src/Novell.Directory.Ldap.NETStandard/LdapIntermediateResponse.cs
@@ -105,7 +105,6 @@ namespace Novell.Directory.Ldap
          *
          * @return The value of the response.
          */
-        [CLSCompliant(false)]
         public byte[] GetValue()
         {
             var tempString =

--- a/src/Novell.Directory.Ldap.NETStandard/LdapMatchingRuleSchema.cs
+++ b/src/Novell.Directory.Ldap.NETStandard/LdapMatchingRuleSchema.cs
@@ -120,7 +120,7 @@ namespace Novell.Directory.Ldap
                 Description = matchParser.Description;
                 Obsolete = matchParser.Obsolete;
                 SyntaxString = matchParser.Syntax;
-                if ((object)rawMatchingRuleUse != null)
+                if (rawMatchingRuleUse != null)
                 {
                     var matchUseParser = new SchemaParser(rawMatchingRuleUse);
                     Attributes = matchUseParser.Applies;
@@ -162,7 +162,7 @@ namespace Novell.Directory.Ldap
             var valueBuffer = new StringBuilder("( ");
             string token;
 
-            if ((object)(token = Id) != null)
+            if ((token = Id) != null)
             {
                 valueBuffer.Append(token);
             }
@@ -188,7 +188,7 @@ namespace Novell.Directory.Ldap
                 }
             }
 
-            if ((object)(token = Description) != null)
+            if ((token = Description) != null)
             {
                 valueBuffer.Append(" DESC ");
                 valueBuffer.Append("'" + token + "'");
@@ -199,7 +199,7 @@ namespace Novell.Directory.Ldap
                 valueBuffer.Append(" OBSOLETE");
             }
 
-            if ((object)(token = SyntaxString) != null)
+            if ((token = SyntaxString) != null)
             {
                 valueBuffer.Append(" SYNTAX ");
                 valueBuffer.Append(token);

--- a/src/Novell.Directory.Ldap.NETStandard/LdapMatchingRuleUseSchema.cs
+++ b/src/Novell.Directory.Ldap.NETStandard/LdapMatchingRuleUseSchema.cs
@@ -138,7 +138,7 @@ namespace Novell.Directory.Ldap
             var valueBuffer = new StringBuilder("( ");
             string token;
 
-            if ((object)(token = Id) != null)
+            if ((token = Id) != null)
             {
                 valueBuffer.Append(token);
             }
@@ -164,7 +164,7 @@ namespace Novell.Directory.Ldap
                 }
             }
 
-            if ((object)(token = Description) != null)
+            if ((token = Description) != null)
             {
                 valueBuffer.Append(" DESC ");
                 valueBuffer.Append("'" + token + "'");

--- a/src/Novell.Directory.Ldap.NETStandard/LdapMessage.cs
+++ b/src/Novell.Directory.Ldap.NETStandard/LdapMessage.cs
@@ -511,7 +511,7 @@ namespace Novell.Directory.Ldap
         {
             get
             {
-                if ((object)_stringTag != null)
+                if (_stringTag != null)
                 {
                     return _stringTag;
                 }

--- a/src/Novell.Directory.Ldap.NETStandard/LdapModifyDNRequest.cs
+++ b/src/Novell.Directory.Ldap.NETStandard/LdapModifyDNRequest.cs
@@ -75,7 +75,7 @@ namespace Novell.Directory.Ldap
             : base(
                 ModifyRdnRequest,
                 new RfcModifyDnRequest(new RfcLdapDn(dn), new RfcRelativeLdapDn(newRdn), new Asn1Boolean(deleteOldRdn),
-                    (object)newParentdn != null ? new RfcLdapDn(newParentdn) : null), cont)
+                    newParentdn != null ? new RfcLdapDn(newParentdn) : null), cont)
         {
         }
 

--- a/src/Novell.Directory.Ldap.NETStandard/LdapNameFormSchema.cs
+++ b/src/Novell.Directory.Ldap.NETStandard/LdapNameFormSchema.cs
@@ -124,14 +124,14 @@ namespace Novell.Directory.Ldap
                     parser.Names.CopyTo(names, 0);
                 }
 
-                if ((object)parser.Id != null)
+                if (parser.Id != null)
                 {
-                    Oid = new StringBuilder(parser.Id).ToString();
+                    Oid = parser.Id;
                 }
 
-                if ((object)parser.Description != null)
+                if (parser.Description != null)
                 {
-                    Description = new StringBuilder(parser.Description).ToString();
+                    Description = parser.Description;
                 }
 
                 if (parser.Required != null)
@@ -146,7 +146,7 @@ namespace Novell.Directory.Ldap
                     parser.Optional.CopyTo(OptionalNamingAttributes, 0);
                 }
 
-                if ((object)parser.ObjectClass != null)
+                if (parser.ObjectClass != null)
                 {
                     ObjectClass = parser.ObjectClass;
                 }

--- a/src/Novell.Directory.Ldap.NETStandard/LdapNameFormSchema.cs
+++ b/src/Novell.Directory.Ldap.NETStandard/LdapNameFormSchema.cs
@@ -206,7 +206,7 @@ namespace Novell.Directory.Ldap
             var valueBuffer = new StringBuilder("( ");
             string token;
 
-            if ((object)(token = Id) != null)
+            if ((token = Id) != null)
             {
                 valueBuffer.Append(token);
             }
@@ -232,7 +232,7 @@ namespace Novell.Directory.Ldap
                 }
             }
 
-            if ((object)(token = Description) != null)
+            if ((token = Description) != null)
             {
                 valueBuffer.Append(" DESC ");
                 valueBuffer.Append("'" + token + "'");
@@ -243,7 +243,7 @@ namespace Novell.Directory.Ldap
                 valueBuffer.Append(" OBSOLETE");
             }
 
-            if ((object)(token = ObjectClass) != null)
+            if ((token = ObjectClass) != null)
             {
                 valueBuffer.Append(" OC ");
                 valueBuffer.Append("'" + token + "'");

--- a/src/Novell.Directory.Ldap.NETStandard/LdapObjectClassSchema.cs
+++ b/src/Novell.Directory.Ldap.NETStandard/LdapObjectClassSchema.cs
@@ -149,12 +149,12 @@ namespace Novell.Directory.Ldap
                     parser.Names.CopyTo(names, 0);
                 }
 
-                if ((object)parser.Id != null)
+                if (parser.Id != null)
                 {
                     Oid = parser.Id;
                 }
 
-                if ((object)parser.Description != null)
+                if (parser.Description != null)
                 {
                     Description = parser.Description;
                 }
@@ -250,7 +250,7 @@ namespace Novell.Directory.Ldap
             var valueBuffer = new StringBuilder("( ");
             string token;
 
-            if ((object)(token = Id) != null)
+            if ((token = Id) != null)
             {
                 valueBuffer.Append(token);
             }
@@ -276,7 +276,7 @@ namespace Novell.Directory.Ldap
                 }
             }
 
-            if ((object)(token = Description) != null)
+            if ((token = Description) != null)
             {
                 valueBuffer.Append(" DESC ");
                 valueBuffer.Append("'" + token + "'");

--- a/src/Novell.Directory.Ldap.NETStandard/LdapReferralException.cs
+++ b/src/Novell.Directory.Ldap.NETStandard/LdapReferralException.cs
@@ -262,7 +262,7 @@ namespace Novell.Directory.Ldap
             var msg = GetExceptionString("LdapReferralException");
 
             // Add failed referral information
-            if ((object)FailedReferral != null)
+            if (FailedReferral != null)
             {
                 tmsg = ResourcesHandler.GetMessage(
                     "FAILED_REFERRAL",

--- a/src/Novell.Directory.Ldap.NETStandard/LdapResponse.cs
+++ b/src/Novell.Directory.Ldap.NETStandard/LdapResponse.cs
@@ -220,11 +220,11 @@ namespace Novell.Directory.Ldap
                         {
                             // get the referral URL
                             var urlRef = new LdapUrl(aRef);
-                            if ((object)urlRef.GetDn() == null)
+                            if (urlRef.GetDn() == null)
                             {
                                 var origMsg = Asn1Object.RequestingMessage.Asn1Object;
                                 string dn;
-                                if ((object)(dn = origMsg.RequestDn) != null)
+                                if ((dn = origMsg.RequestDn) != null)
                                 {
                                     urlRef.SetDn(dn);
                                     aRef = urlRef.ToString();
@@ -388,12 +388,12 @@ namespace Novell.Directory.Ldap
         {
             Asn1Sequence ret;
 
-            if ((object)matchedDn == null)
+            if (matchedDn == null)
             {
                 matchedDn = string.Empty;
             }
 
-            if ((object)serverMessage == null)
+            if (serverMessage == null)
             {
                 serverMessage = string.Empty;
             }

--- a/src/Novell.Directory.Ldap.NETStandard/LdapSchema.cs
+++ b/src/Novell.Directory.Ldap.NETStandard/LdapSchema.cs
@@ -453,7 +453,7 @@ namespace Novell.Directory.Ldap
         /// </param>
         private LdapSchemaElement GetSchemaElement(int schemaType, string key)
         {
-            if ((object)key == null || key.ToUpper().Equals(string.Empty.ToUpper()))
+            if (string.IsNullOrEmpty(key))
             {
                 return null;
             }

--- a/src/Novell.Directory.Ldap.NETStandard/LdapSyntaxSchema.cs
+++ b/src/Novell.Directory.Ldap.NETStandard/LdapSyntaxSchema.cs
@@ -86,12 +86,12 @@ namespace Novell.Directory.Ldap
             {
                 var parser = new SchemaParser(raw);
 
-                if ((object)parser.Id != null)
+                if (parser.Id != null)
                 {
                     Oid = parser.Id;
                 }
 
-                if ((object)parser.Description != null)
+                if (parser.Description != null)
                 {
                     Description = parser.Description;
                 }
@@ -123,12 +123,12 @@ namespace Novell.Directory.Ldap
             var valueBuffer = new StringBuilder("( ");
             string token;
 
-            if ((object)(token = Id) != null)
+            if ((token = Id) != null)
             {
                 valueBuffer.Append(token);
             }
 
-            if ((object)(token = Description) != null)
+            if ((token = Description) != null)
             {
                 valueBuffer.Append(" DESC ");
                 valueBuffer.Append("'" + token + "'");

--- a/src/Novell.Directory.Ldap.NETStandard/LdapUrl.cs
+++ b/src/Novell.Directory.Ldap.NETStandard/LdapUrl.cs
@@ -589,7 +589,7 @@ namespace Novell.Directory.Ldap
                 url.Append(":" + _port);
             }
 
-            if ((object)_dn == null && AttributeArray == null && Scope == DefaultScope && (object)Filter == null &&
+            if (_dn == null && AttributeArray == null && Scope == DefaultScope && Filter == null &&
                 Extensions == null)
 
             {
@@ -598,13 +598,13 @@ namespace Novell.Directory.Ldap
 
             url.Append("/");
 
-            if ((object)_dn != null)
+            if (_dn != null)
 
             {
                 url.Append(_dn);
             }
 
-            if (AttributeArray == null && Scope == DefaultScope && (object)Filter == null && Extensions == null)
+            if (AttributeArray == null && Scope == DefaultScope && Filter == null && Extensions == null)
 
             {
                 return url.ToString();
@@ -632,7 +632,7 @@ namespace Novell.Directory.Ldap
                 }
             }
 
-            if (Scope == DefaultScope && (object)Filter == null && Extensions == null)
+            if (Scope == DefaultScope && Filter == null && Extensions == null)
 
             {
                 return url.ToString();
@@ -658,7 +658,7 @@ namespace Novell.Directory.Ldap
                 }
             }
 
-            if ((object)Filter == null && Extensions == null)
+            if (Filter == null && Extensions == null)
 
             {
                 return url.ToString();
@@ -666,7 +666,7 @@ namespace Novell.Directory.Ldap
 
             // filter
 
-            if ((object)Filter == null)
+            if (Filter == null)
 
             {
                 url.Append("?");
@@ -802,7 +802,7 @@ namespace Novell.Directory.Ldap
 
             var scanEnd = url.Length;
 
-            if ((object)url == null)
+            if (url == null)
 
             {
                 throw new UriFormatException("LdapUrl: URL cannot be null");

--- a/src/Novell.Directory.Ldap.NETStandard/Properties/AssemblyInfo.cs
+++ b/src/Novell.Directory.Ldap.NETStandard/Properties/AssemblyInfo.cs
@@ -47,7 +47,6 @@ using System.Reflection;
 [assembly: AssemblyCopyright(" (C) 2003 Novell, Inc, 2016 dsbenghe")]
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
-[assembly: CLSCompliant(true)]
 
 //
 // Version information for an assembly consists of the following four values:

--- a/src/Novell.Directory.Ldap.NETStandard/Rfc2251/RfcAddRequest.cs
+++ b/src/Novell.Directory.Ldap.NETStandard/Rfc2251/RfcAddRequest.cs
@@ -77,7 +77,7 @@ namespace Novell.Directory.Ldap.Rfc2251
             : base(origRequest, origRequest.Length)
         {
             // Replace the base if specified, otherwise keep original base
-            if ((object)baseRenamed != null)
+            if (baseRenamed != null)
             {
                 set_Renamed(0, new RfcLdapDn(baseRenamed));
             }

--- a/src/Novell.Directory.Ldap.NETStandard/Rfc2251/RfcAddResponse.cs
+++ b/src/Novell.Directory.Ldap.NETStandard/Rfc2251/RfcAddResponse.cs
@@ -52,7 +52,6 @@ namespace Novell.Directory.Ldap.Rfc2251
         ///     The only time a client will create a AddResponse is when it is
         ///     decoding it from an InputStream.
         /// </summary>
-        [CLSCompliant(false)]
         public RfcAddResponse(IAsn1Decoder dec, Stream inRenamed, int len)
             : base(dec, inRenamed, len)
         {

--- a/src/Novell.Directory.Ldap.NETStandard/Rfc2251/RfcAttributeDescription.cs
+++ b/src/Novell.Directory.Ldap.NETStandard/Rfc2251/RfcAttributeDescription.cs
@@ -49,7 +49,6 @@ namespace Novell.Directory.Ldap.Rfc2251
         }
 
         /// <summary> </summary>
-        [CLSCompliant(false)]
         public RfcAttributeDescription(IAsn1Decoder dec, Stream inRenamed, int len)
             : base(dec, inRenamed, len)
         {

--- a/src/Novell.Directory.Ldap.NETStandard/Rfc2251/RfcAttributeValue.cs
+++ b/src/Novell.Directory.Ldap.NETStandard/Rfc2251/RfcAttributeValue.cs
@@ -48,7 +48,6 @@ namespace Novell.Directory.Ldap.Rfc2251
         }
 
         /// <summary> </summary>
-        [CLSCompliant(false)]
         public RfcAttributeValue(byte[] valueRenamed)
             : base(valueRenamed)
         {

--- a/src/Novell.Directory.Ldap.NETStandard/Rfc2251/RfcAttributeValueAssertion.cs
+++ b/src/Novell.Directory.Ldap.NETStandard/Rfc2251/RfcAttributeValueAssertion.cs
@@ -75,7 +75,6 @@ namespace Novell.Directory.Ldap.Rfc2251
         /// <returns>
         ///     the assertion value.
         /// </returns>
-        [CLSCompliant(false)]
         public byte[] AssertionValue => ((RfcAssertionValue)get_Renamed(1)).ByteValue();
     }
 }

--- a/src/Novell.Directory.Ldap.NETStandard/Rfc2251/RfcAuthenticationChoice.cs
+++ b/src/Novell.Directory.Ldap.NETStandard/Rfc2251/RfcAuthenticationChoice.cs
@@ -56,7 +56,6 @@ namespace Novell.Directory.Ldap.Rfc2251
         {
         }
 
-        [CLSCompliant(false)]
         public RfcAuthenticationChoice(string mechanism, byte[] credentials)
             : base(
                 new Asn1Tagged(

--- a/src/Novell.Directory.Ldap.NETStandard/Rfc2251/RfcBindRequest.cs
+++ b/src/Novell.Directory.Ldap.NETStandard/Rfc2251/RfcBindRequest.cs
@@ -81,7 +81,7 @@ namespace Novell.Directory.Ldap.Rfc2251
             : base(origRequest, origRequest.Length)
         {
             // Replace the dn if specified, otherwise keep original base
-            if ((object)baseRenamed != null)
+            if (baseRenamed != null)
             {
                 set_Renamed(1, new RfcLdapDn(baseRenamed));
             }

--- a/src/Novell.Directory.Ldap.NETStandard/Rfc2251/RfcBindRequest.cs
+++ b/src/Novell.Directory.Ldap.NETStandard/Rfc2251/RfcBindRequest.cs
@@ -67,7 +67,6 @@ namespace Novell.Directory.Ldap.Rfc2251
             Add(auth);
         }
 
-        [CLSCompliant(false)]
         public RfcBindRequest(int version, string dn, string mechanism, byte[] credentials)
             : this(new Asn1Integer(version), new RfcLdapDn(dn), new RfcAuthenticationChoice(mechanism, credentials))
         {

--- a/src/Novell.Directory.Ldap.NETStandard/Rfc2251/RfcBindResponse.cs
+++ b/src/Novell.Directory.Ldap.NETStandard/Rfc2251/RfcBindResponse.cs
@@ -56,7 +56,6 @@ namespace Novell.Directory.Ldap.Rfc2251
         ///     Note: If serverSaslCreds is included in the BindResponse, it does not
         ///     need to be decoded since it is already an OCTET STRING.
         /// </summary>
-        [CLSCompliant(false)]
         public RfcBindResponse(IAsn1Decoder dec, Stream inRenamed, int len)
             : base(dec, inRenamed, len)
         {

--- a/src/Novell.Directory.Ldap.NETStandard/Rfc2251/RfcCompareRequest.cs
+++ b/src/Novell.Directory.Ldap.NETStandard/Rfc2251/RfcCompareRequest.cs
@@ -69,7 +69,7 @@ namespace Novell.Directory.Ldap.Rfc2251
             : base(origRequest, origRequest.Length)
         {
             // Replace the base if specified, otherwise keep original base
-            if ((object)baseRenamed != null)
+            if (baseRenamed != null)
             {
                 set_Renamed(0, new RfcLdapDn(baseRenamed));
             }

--- a/src/Novell.Directory.Ldap.NETStandard/Rfc2251/RfcCompareResponse.cs
+++ b/src/Novell.Directory.Ldap.NETStandard/Rfc2251/RfcCompareResponse.cs
@@ -52,7 +52,6 @@ namespace Novell.Directory.Ldap.Rfc2251
         ///     The only time a client will create a CompareResponse is when it is
         ///     decoding it from an InputStream.
         /// </summary>
-        [CLSCompliant(false)]
         public RfcCompareResponse(IAsn1Decoder dec, Stream inRenamed, int len)
             : base(dec, inRenamed, len)
         {

--- a/src/Novell.Directory.Ldap.NETStandard/Rfc2251/RfcControl.cs
+++ b/src/Novell.Directory.Ldap.NETStandard/Rfc2251/RfcControl.cs
@@ -84,7 +84,6 @@ namespace Novell.Directory.Ldap.Rfc2251
         }
 
         /// <summary> Constructs a Control object by decoding it from an InputStream.</summary>
-        [CLSCompliant(false)]
         public RfcControl(IAsn1Decoder dec, Stream inRenamed, int len)
             : base(dec, inRenamed, len)
         {

--- a/src/Novell.Directory.Ldap.NETStandard/Rfc2251/RfcControls.cs
+++ b/src/Novell.Directory.Ldap.NETStandard/Rfc2251/RfcControls.cs
@@ -62,7 +62,6 @@ namespace Novell.Directory.Ldap.Rfc2251
         }
 
         /// <summary> Constructs a Controls object by decoding it from an InputStream.</summary>
-        [CLSCompliant(false)]
         public RfcControls(IAsn1Decoder dec, Stream inRenamed, int len)
             : base(dec, inRenamed, len)
         {

--- a/src/Novell.Directory.Ldap.NETStandard/Rfc2251/RfcDelRequest.cs
+++ b/src/Novell.Directory.Ldap.NETStandard/Rfc2251/RfcDelRequest.cs
@@ -64,7 +64,6 @@ namespace Novell.Directory.Ldap.Rfc2251
         /// <param name="dn">
         ///     The Distinguished Name of the entry to delete.
         /// </param>
-        [CLSCompliant(false)]
         public RfcDelRequest(byte[] dn)
             : base(dn)
         {

--- a/src/Novell.Directory.Ldap.NETStandard/Rfc2251/RfcDelRequest.cs
+++ b/src/Novell.Directory.Ldap.NETStandard/Rfc2251/RfcDelRequest.cs
@@ -72,7 +72,7 @@ namespace Novell.Directory.Ldap.Rfc2251
 
         public IRfcRequest DupRequest(string baseRenamed, string filter, bool request)
         {
-            if ((object)baseRenamed == null)
+            if (baseRenamed == null)
             {
                 return new RfcDelRequest(ByteValue());
             }

--- a/src/Novell.Directory.Ldap.NETStandard/Rfc2251/RfcDelResponse.cs
+++ b/src/Novell.Directory.Ldap.NETStandard/Rfc2251/RfcDelResponse.cs
@@ -52,7 +52,6 @@ namespace Novell.Directory.Ldap.Rfc2251
         ///     The only time a client will create a DelResponse is when it is
         ///     decoding it from an InputStream.
         /// </summary>
-        [CLSCompliant(false)]
         public RfcDelResponse(IAsn1Decoder dec, Stream inRenamed, int len)
             : base(dec, inRenamed, len)
         {

--- a/src/Novell.Directory.Ldap.NETStandard/Rfc2251/RfcExtendedResponse.cs
+++ b/src/Novell.Directory.Ldap.NETStandard/Rfc2251/RfcExtendedResponse.cs
@@ -65,7 +65,6 @@ namespace Novell.Directory.Ldap.Rfc2251
         ///     The only time a client will create a ExtendedResponse is when it is
         ///     decoding it from an InputStream.
         /// </summary>
-        [CLSCompliant(false)]
         public RfcExtendedResponse(IAsn1Decoder dec, Stream inRenamed, int len)
             : base(dec, inRenamed, len)
         {
@@ -103,7 +102,6 @@ namespace Novell.Directory.Ldap.Rfc2251
         public RfcLdapOid ResponseName => _responseNameIndex != 0 ? (RfcLdapOid)get_Renamed(_responseNameIndex) : null;
 
         /// <summary> </summary>
-        [CLSCompliant(false)]
         public Asn1OctetString Response => _responseIndex != 0 ? (Asn1OctetString)get_Renamed(_responseIndex) : null;
 
         // *************************************************************************

--- a/src/Novell.Directory.Ldap.NETStandard/Rfc2251/RfcFilter.cs
+++ b/src/Novell.Directory.Ldap.NETStandard/Rfc2251/RfcFilter.cs
@@ -146,9 +146,9 @@ namespace Novell.Directory.Ldap.Rfc2251
         /// <summary> Parses an RFC 2251 filter string into an ASN.1 Ldap Filter object.</summary>
         private Asn1Tagged Parse(string filterExpr)
         {
-            if ((object)filterExpr == null || filterExpr.Equals(string.Empty))
+            if (string.IsNullOrEmpty(filterExpr))
             {
-                filterExpr = new StringBuilder("(objectclass=*)").ToString();
+                filterExpr = "(objectclass=*)";
             }
 
             int idx;
@@ -296,7 +296,7 @@ namespace Novell.Directory.Ldap.Rfc2251
                                 var tokCnt = sub.Count;
                                 var cnt = 0;
 
-                                var lastTok = new StringBuilder(string.Empty).ToString();
+                                var lastTok = string.Empty;
 
                                 while (sub.HasMoreTokens())
                                 {

--- a/src/Novell.Directory.Ldap.NETStandard/Rfc2251/RfcFilter.cs
+++ b/src/Novell.Directory.Ldap.NETStandard/Rfc2251/RfcFilter.cs
@@ -395,8 +395,8 @@ namespace Novell.Directory.Ldap.Rfc2251
                             tag = new Asn1Tagged(
                                 new Asn1Identifier(Asn1Identifier.Context, true, ExtensibleMatch),
                                 new RfcMatchingRuleAssertion(
-                                    (object)matchingRule == null ? null : new RfcMatchingRuleId(matchingRule),
-                                    (object)type == null ? null : new RfcAttributeDescription(type),
+                                    matchingRule == null ? null : new RfcMatchingRuleId(matchingRule),
+                                    type == null ? null : new RfcAttributeDescription(type),
                                     new RfcAssertionValue(UnescapeString(valueRenamed)),
                                     dnAttributes == false ? null : new Asn1Boolean(true)), false);
                             break;
@@ -834,8 +834,8 @@ namespace Novell.Directory.Ldap.Rfc2251
             Asn1Object current = new Asn1Tagged(
                 new Asn1Identifier(Asn1Identifier.Context, true, ExtensibleMatch),
                 new RfcMatchingRuleAssertion(
-                    (object)matchingRule == null ? null : new RfcMatchingRuleId(matchingRule),
-                    (object)attrName == null ? null : new RfcAttributeDescription(attrName),
+                    matchingRule == null ? null : new RfcMatchingRuleId(matchingRule),
+                    attrName == null ? null : new RfcAttributeDescription(attrName),
                     new RfcAssertionValue(valueRenamed), useDnMatching == false ? null : new Asn1Boolean(true)), false);
             AddObject(current);
         }

--- a/src/Novell.Directory.Ldap.NETStandard/Rfc2251/RfcFilter.cs
+++ b/src/Novell.Directory.Ldap.NETStandard/Rfc2251/RfcFilter.cs
@@ -519,9 +519,7 @@ namespace Novell.Directory.Ldap.Rfc2251
                             {
                                 // char > 0x7f, could be encoded in 2 or 3 bytes
                                 ca[0] = ch;
-                                var encoder = Encoding.GetEncoding("utf-8");
-                                var ibytes = encoder.GetBytes(new string(ca));
-                                utf8Bytes = ibytes;
+                                utf8Bytes = Encoding.UTF8.GetBytes(ca);
 
                                 // copy utf8 encoded character into octets
                                 Array.Copy(utf8Bytes, 0, octets, iOctets, utf8Bytes.Length);
@@ -535,11 +533,8 @@ namespace Novell.Directory.Ldap.Rfc2251
                             // found invalid character
                             var escString = string.Empty;
                             ca[0] = ch;
-                            var encoder = Encoding.GetEncoding("utf-8");
-                            var ibytes = encoder.GetBytes(new string(ca));
-                            utf8Bytes = ibytes;
+                            utf8Bytes = Encoding.UTF8.GetBytes(ca);
 
-// utf8Bytes = new System.String(ca).getBytes("UTF-8");
                             for (var i = 0; i < utf8Bytes.Length; i++)
                             {
                                 var u = utf8Bytes[i];
@@ -560,6 +555,7 @@ namespace Novell.Directory.Ldap.Rfc2251
                     }
                     catch (IOException ue)
                     {
+                        // TODO: This can be removed? In Java, Encoding.GetEncoding("utf-8") might not work, but in .net we always have UTF-8
                         throw new Exception("UTF-8 String encoding not supported by JVM", ue);
                     }
                 }
@@ -1060,21 +1056,9 @@ namespace Novell.Directory.Ldap.Rfc2251
         /// </summary>
         private static string ByteString(byte[] valueRenamed)
         {
-            string toReturn = null;
             if (Base64.IsValidUtf8(valueRenamed, true))
             {
-                try
-                {
-                    var encoder = Encoding.GetEncoding("utf-8");
-                    var dchar = encoder.GetChars(valueRenamed);
-                    toReturn = new string(dchar);
-
-// toReturn = new String(value_Renamed, "UTF-8");
-                }
-                catch (IOException e)
-                {
-                    throw new Exception("Default JVM does not support UTF-8 encoding" + e);
-                }
+                return valueRenamed.ToUtf8String();
             }
             else
             {
@@ -1096,10 +1080,8 @@ namespace Novell.Directory.Ldap.Rfc2251
                     }
                 }
 
-                toReturn = binary.ToString();
+                return binary.ToString();
             }
-
-            return toReturn;
         }
 
         /// <summary>

--- a/src/Novell.Directory.Ldap.NETStandard/Rfc2251/RfcFilter.cs
+++ b/src/Novell.Directory.Ldap.NETStandard/Rfc2251/RfcFilter.cs
@@ -679,7 +679,6 @@ namespace Novell.Directory.Ldap.Rfc2251
         ///     @throws LdapLocalException   Occurs if this method is called out of
         ///     sequence or the type added is out of sequence.
         /// </param>
-        [CLSCompliant(false)]
         public void AddSubstring(int type, byte[] valueRenamed)
         {
             try
@@ -762,7 +761,6 @@ namespace Novell.Directory.Ldap.Rfc2251
         ///     @throws LdapLocalException
         ///     Occurs when the filter type is not a valid attribute assertion.
         /// </param>
-        [CLSCompliant(false)]
         public void AddAttributeValueAssertion(int rfcType, string attrName, byte[] valueRenamed)
         {
             if (_filterStack != null && !(_filterStack.Count == 0) && _filterStack.Peek() is Asn1SequenceOf)
@@ -823,7 +821,6 @@ namespace Novell.Directory.Ldap.Rfc2251
         ///     @throws LdapLocalException
         ///     Occurs when addExtensibleMatch is called out of sequence.
         /// </param>
-        [CLSCompliant(false)]
         public void AddExtensibleMatch(string matchingRule, string attrName, byte[] valueRenamed,
             bool useDnMatching)
         {

--- a/src/Novell.Directory.Ldap.NETStandard/Rfc2251/RfcIntermediateResponse.cs
+++ b/src/Novell.Directory.Ldap.NETStandard/Rfc2251/RfcIntermediateResponse.cs
@@ -96,7 +96,6 @@ namespace Novell.Directory.Ldap.Rfc2251
          * oid of the response. The element at m_responseValueIndex will be set
          * to an ASN1OctetString containing the value bytes.
          */
-        [CLSCompliant(false)]
         public RfcIntermediateResponse(IAsn1Decoder dec, Stream inRenamed, int len)
             : base(dec, inRenamed, len)
 

--- a/src/Novell.Directory.Ldap.NETStandard/Rfc2251/RfcLdapDN.cs
+++ b/src/Novell.Directory.Ldap.NETStandard/Rfc2251/RfcLdapDN.cs
@@ -53,7 +53,6 @@ namespace Novell.Directory.Ldap.Rfc2251
         }
 
         /// <summary> </summary>
-        [CLSCompliant(false)]
         public RfcLdapDn(byte[] s)
             : base(s)
         {

--- a/src/Novell.Directory.Ldap.NETStandard/Rfc2251/RfcLdapMessage.cs
+++ b/src/Novell.Directory.Ldap.NETStandard/Rfc2251/RfcLdapMessage.cs
@@ -137,7 +137,6 @@ namespace Novell.Directory.Ldap.Rfc2251
         }
 
         /// <summary> Will decode an RfcLdapMessage directly from an InputStream.</summary>
-        [CLSCompliant(false)]
         public RfcLdapMessage(IAsn1Decoder dec, Stream inRenamed, int len)
             : base(dec, inRenamed, len)
         {

--- a/src/Novell.Directory.Ldap.NETStandard/Rfc2251/RfcLdapOID.cs
+++ b/src/Novell.Directory.Ldap.NETStandard/Rfc2251/RfcLdapOID.cs
@@ -48,7 +48,6 @@ namespace Novell.Directory.Ldap.Rfc2251
         }
 
         /// <summary> </summary>
-        [CLSCompliant(false)]
         public RfcLdapOid(byte[] s)
             : base(s)
         {

--- a/src/Novell.Directory.Ldap.NETStandard/Rfc2251/RfcLdapResult.cs
+++ b/src/Novell.Directory.Ldap.NETStandard/Rfc2251/RfcLdapResult.cs
@@ -148,7 +148,6 @@ namespace Novell.Directory.Ldap.Rfc2251
         }
 
         /// <summary> Constructs an RfcLdapResult from the inputstream.</summary>
-        [CLSCompliant(false)]
         public RfcLdapResult(IAsn1Decoder dec, Stream inRenamed, int len)
             : base(dec, inRenamed, len)
         {

--- a/src/Novell.Directory.Ldap.NETStandard/Rfc2251/RfcLdapString.cs
+++ b/src/Novell.Directory.Ldap.NETStandard/Rfc2251/RfcLdapString.cs
@@ -46,14 +46,12 @@ namespace Novell.Directory.Ldap.Rfc2251
         }
 
         /// <summary> </summary>
-        [CLSCompliant(false)]
         public RfcLdapString(byte[] ba)
             : base(ba)
         {
         }
 
         /// <summary> </summary>
-        [CLSCompliant(false)]
         public RfcLdapString(IAsn1Decoder dec, Stream inRenamed, int len)
             : base(dec, inRenamed, len)
         {

--- a/src/Novell.Directory.Ldap.NETStandard/Rfc2251/RfcModifyDNRequest.cs
+++ b/src/Novell.Directory.Ldap.NETStandard/Rfc2251/RfcModifyDNRequest.cs
@@ -79,7 +79,7 @@ namespace Novell.Directory.Ldap.Rfc2251
             : base(origRequest, origRequest.Length)
         {
             // Replace the base if specified, otherwise keep original base
-            if ((object)baseRenamed != null)
+            if (baseRenamed != null)
             {
                 set_Renamed(0, new RfcLdapDn(baseRenamed));
             }

--- a/src/Novell.Directory.Ldap.NETStandard/Rfc2251/RfcModifyDNResponse.cs
+++ b/src/Novell.Directory.Ldap.NETStandard/Rfc2251/RfcModifyDNResponse.cs
@@ -49,7 +49,6 @@ namespace Novell.Directory.Ldap.Rfc2251
         // *************************************************************************
 
         /// <summary> Create a ModifyDNResponse by decoding it from an InputStream.</summary>
-        [CLSCompliant(false)]
         public RfcModifyDnResponse(IAsn1Decoder dec, Stream inRenamed, int len)
             : base(dec, inRenamed, len)
         {

--- a/src/Novell.Directory.Ldap.NETStandard/Rfc2251/RfcModifyRequest.cs
+++ b/src/Novell.Directory.Ldap.NETStandard/Rfc2251/RfcModifyRequest.cs
@@ -69,7 +69,7 @@ namespace Novell.Directory.Ldap.Rfc2251
             : base(origRequest, origRequest.Length)
         {
             // Replace the base if specified, otherwise keep original base
-            if ((object)baseRenamed != null)
+            if (baseRenamed != null)
             {
                 set_Renamed(0, new RfcLdapDn(baseRenamed));
             }

--- a/src/Novell.Directory.Ldap.NETStandard/Rfc2251/RfcModifyResponse.cs
+++ b/src/Novell.Directory.Ldap.NETStandard/Rfc2251/RfcModifyResponse.cs
@@ -52,7 +52,6 @@ namespace Novell.Directory.Ldap.Rfc2251
         ///     The only time a client will create a ModifyResponse is when it is
         ///     decoding it from an InputStream.
         /// </summary>
-        [CLSCompliant(false)]
         public RfcModifyResponse(IAsn1Decoder dec, Stream inRenamed, int len)
             : base(dec, inRenamed, len)
         {

--- a/src/Novell.Directory.Ldap.NETStandard/Rfc2251/RfcReferral.cs
+++ b/src/Novell.Directory.Ldap.NETStandard/Rfc2251/RfcReferral.cs
@@ -52,7 +52,6 @@ namespace Novell.Directory.Ldap.Rfc2251
         ///     The only time a Referral object is constructed, is when we are
         ///     decoding an RfcLdapResult or COMPONENTS OF RfcLdapResult.
         /// </summary>
-        [CLSCompliant(false)]
         public RfcReferral(IAsn1Decoder dec, Stream inRenamed, int len)
             : base(dec, inRenamed, len)
         {

--- a/src/Novell.Directory.Ldap.NETStandard/Rfc2251/RfcSearchRequest.cs
+++ b/src/Novell.Directory.Ldap.NETStandard/Rfc2251/RfcSearchRequest.cs
@@ -85,7 +85,7 @@ namespace Novell.Directory.Ldap.Rfc2251
             : base(origRequest, origRequest.Length)
         {
             // Replace the base if specified, otherwise keep original base
-            if ((object)baseRenamed != null)
+            if (baseRenamed != null)
             {
                 set_Renamed(0, new RfcLdapDn(baseRenamed));
             }
@@ -103,7 +103,7 @@ namespace Novell.Directory.Ldap.Rfc2251
             }
 
             // Replace the filter if specified, otherwise keep original filter
-            if ((object)filter != null)
+            if (filter != null)
             {
                 set_Renamed(6, new RfcFilter(filter));
             }

--- a/src/Novell.Directory.Ldap.NETStandard/Rfc2251/RfcSearchResultDone.cs
+++ b/src/Novell.Directory.Ldap.NETStandard/Rfc2251/RfcSearchResultDone.cs
@@ -49,7 +49,6 @@ namespace Novell.Directory.Ldap.Rfc2251
         // *************************************************************************
 
         /// <summary> Decode a search result done from the input stream.</summary>
-        [CLSCompliant(false)]
         public RfcSearchResultDone(IAsn1Decoder dec, Stream inRenamed, int len)
             : base(dec, inRenamed, len)
         {

--- a/src/Novell.Directory.Ldap.NETStandard/Rfc2251/RfcSearchResultEntry.cs
+++ b/src/Novell.Directory.Ldap.NETStandard/Rfc2251/RfcSearchResultEntry.cs
@@ -54,7 +54,6 @@ namespace Novell.Directory.Ldap.Rfc2251
         ///     The only time a client will create a SearchResultEntry is when it is
         ///     decoding it from an InputStream.
         /// </summary>
-        [CLSCompliant(false)]
         public RfcSearchResultEntry(IAsn1Decoder dec, Stream inRenamed, int len)
             : base(dec, inRenamed, len)
         {

--- a/src/Novell.Directory.Ldap.NETStandard/Rfc2251/RfcSearchResultReference.cs
+++ b/src/Novell.Directory.Ldap.NETStandard/Rfc2251/RfcSearchResultReference.cs
@@ -52,7 +52,6 @@ namespace Novell.Directory.Ldap.Rfc2251
         ///     The only time a client will create a SearchResultReference is when it is
         ///     decoding it from an InputStream.
         /// </summary>
-        [CLSCompliant(false)]
         public RfcSearchResultReference(IAsn1Decoder dec, Stream inRenamed, int len)
             : base(dec, inRenamed, len)
         {

--- a/src/Novell.Directory.Ldap.NETStandard/RootDseInfo.cs
+++ b/src/Novell.Directory.Ldap.NETStandard/RootDseInfo.cs
@@ -1,0 +1,75 @@
+﻿using System;
+using System.Collections.Generic;
+
+namespace Novell.Directory.Ldap
+{
+    /// <summary>
+    /// The result of calling <see cref="LdapConnectionExtensionMethods.GetRootDseInfo(ILdapConnection)"/>
+    /// </summary>
+    public class RootDseInfo
+    {
+        public string ServerName { get; }
+        public string DefaultNamingContext { get; }
+        public IReadOnlyList<string> NamingContexts { get; }
+        public IReadOnlyList<string> SupportedSaslMechanisms { get; }
+        public IReadOnlyList<string> SupportedCapabilities { get; }
+        public IReadOnlyList<string> SupportedControls { get; }
+        public IReadOnlyList<string> SupportedExtensions { get; }
+        public IReadOnlyList<string> SupportedLDAPPolicies { get; }
+
+        /// <summary>
+        /// All Root DSE Attributes that aren't already part of other properties of this class
+        /// </summary>
+        public IReadOnlyDictionary<string, IReadOnlyList<string>> OtherAttributes { get; }
+
+        public RootDseInfo(LdapEntry rootDseEntry)
+        {
+            var otherAttributes = new Dictionary<string, IReadOnlyList<string>>();
+            foreach (LdapAttribute attr in rootDseEntry.GetAttributeSet())
+            {
+                switch (attr.Name)
+                {
+                    case "serverName":
+                        ServerName = attr.StringValue;
+                        break;
+                    case "defaultNamingContext":
+                        DefaultNamingContext = attr.StringValue;
+                        break;
+                    case "supportedSASLMechanisms":
+                        SupportedSaslMechanisms = attr.StringValueArray;
+                        break;
+                    case "namingContexts":
+                        NamingContexts = attr.StringValueArray;
+                        break;
+                    case "supportedCapabilities":
+                        SupportedCapabilities = attr.StringValueArray;
+                        break;
+                    case "supportedControl":
+                        SupportedControls = attr.StringValueArray;
+                        break;
+                    case "supportedExtension":
+                        SupportedExtensions = attr.StringValueArray;
+                        break;
+                    case "supportedLDAPPolicies":
+                        SupportedLDAPPolicies = attr.StringValueArray;
+                        break;
+                    default:
+                        otherAttributes[attr.Name] = attr.StringValueArray;
+                        break;
+                }
+            }
+
+            OtherAttributes = otherAttributes;
+
+            // Don't want any of those properties be null
+            ServerName = ServerName ?? "";
+            DefaultNamingContext = DefaultNamingContext ?? "";
+            NamingContexts = NamingContexts ?? Array.Empty<string>();
+            SupportedSaslMechanisms = SupportedSaslMechanisms ?? Array.Empty<string>();
+            SupportedCapabilities = SupportedCapabilities ?? Array.Empty<string>();
+            SupportedControls = SupportedControls ?? Array.Empty<string>();
+            SupportedExtensions = SupportedExtensions ?? Array.Empty<string>();
+            SupportedLDAPPolicies = SupportedLDAPPolicies ?? Array.Empty<string>();
+        }
+    }
+}

--- a/src/Novell.Directory.Ldap.NETStandard/SupportClass.cs
+++ b/src/Novell.Directory.Ldap.NETStandard/SupportClass.cs
@@ -121,7 +121,6 @@ namespace Novell.Directory.Ldap
         ///     The number of characters read. The number will be less than or equal to count depending on the data available
         ///     in the source Stream. Returns -1 if the end of the stream is reached.
         /// </returns>
-        [CLSCompliant(false)]
         public static int ReadInput(Stream sourceStream, ref byte[] target, int start, int count)
         {
             // Returns 0 bytes if not enough space in target
@@ -173,7 +172,6 @@ namespace Novell.Directory.Ldap
         ///     The number of characters read. The number will be less than or equal to count depending on the data available
         ///     in the source TextReader. Returns -1 if the end of the stream is reached.
         /// </returns>
-        [CLSCompliant(false)]
         public static int ReadInput(TextReader sourceTextReader, ref byte[] target, int start, int count)
         {
             // Returns 0 bytes if not enough space in target
@@ -216,7 +214,6 @@ namespace Novell.Directory.Ldap
         /// </summary>
         /// <param name="literal">The literal to return.</param>
         /// <returns>The received value.</returns>
-        [CLSCompliant(false)]
         public static ulong Identity(ulong literal)
         {
             return literal;
@@ -2005,7 +2002,6 @@ namespace Novell.Directory.Ldap
             ///     Computes the hash value for the internal data digest.
             /// </summary>
             /// <returns>The array of signed bytes with the resulting hash value.</returns>
-            [CLSCompliant(false)]
             public byte[] DigestData()
             {
                 var result = Algorithm.ComputeHash(Data);
@@ -2019,7 +2015,6 @@ namespace Novell.Directory.Ldap
             /// </summary>
             /// <param name="newData">The array of bytes for final update to the digest.</param>
             /// <returns>An array of signed bytes with the resulting hash value.</returns>
-            [CLSCompliant(false)]
             public byte[] DigestData(byte[] newData)
             {
                 Update(newData);
@@ -2098,7 +2093,6 @@ namespace Novell.Directory.Ldap
             /// <param name="firstDigest">An array of signed bytes for comparison.</param>
             /// <param name="secondDigest">An array of signed bytes for comparison.</param>
             /// <returns>True if the input digest arrays are equal.</returns>
-            [CLSCompliant(false)]
             public static bool EquivalentDigest(byte[] firstDigest, byte[] secondDigest)
             {
                 var result = false;

--- a/src/Novell.Directory.Ldap.NETStandard/Utilclass/AttributeQualifier.cs
+++ b/src/Novell.Directory.Ldap.NETStandard/Utilclass/AttributeQualifier.cs
@@ -45,7 +45,7 @@ namespace Novell.Directory.Ldap.Utilclass
 
         public AttributeQualifier(string name, string[] valueRenamed)
         {
-            if ((object)name == null || valueRenamed == null)
+            if (name == null || valueRenamed == null)
             {
                 throw new ArgumentException("A null name or value " +
                                             "was passed in for a schema definition qualifier");

--- a/src/Novell.Directory.Ldap.NETStandard/Utilclass/Base64.cs
+++ b/src/Novell.Directory.Ldap.NETStandard/Utilclass/Base64.cs
@@ -170,7 +170,7 @@ namespace Novell.Directory.Ldap.Utilclass
             if (len == 0)
             {
                 // No data, return no data.
-                return new StringBuilder(string.Empty).ToString();
+                return string.Empty;
             }
 
             // every three bytes will be encoded into four bytes

--- a/src/Novell.Directory.Ldap.NETStandard/Utilclass/Base64.cs
+++ b/src/Novell.Directory.Ldap.NETStandard/Utilclass/Base64.cs
@@ -136,18 +136,7 @@ namespace Novell.Directory.Ldap.Utilclass
         ///     a String containing the encoded value of the input.
         /// </returns>
         public static string Encode(string inputString)
-        {
-            try
-            {
-                var encoder = Encoding.GetEncoding("utf-8");
-                var ibytes = encoder.GetBytes(inputString);
-                return Encode(ibytes);
-            }
-            catch (IOException ue)
-            {
-                throw new Exception("US-ASCII String encoding not supported by JVM", ue);
-            }
-        }
+            => Encode(inputString.ToUtf8Bytes());
 
         /// <summary>
         ///     Encodes the specified bytes into a base64 array of bytes.
@@ -601,18 +590,7 @@ namespace Novell.Directory.Ldap.Utilclass
         ///     true if encoding not required for LDIF.
         /// </returns>
         public static bool IsLdifSafe(string str)
-        {
-            try
-            {
-                var encoder = Encoding.GetEncoding("utf-8");
-                var ibytes = encoder.GetBytes(str);
-                return IsLdifSafe(ibytes);
-            }
-            catch (IOException ue)
-            {
-                throw new Exception("UTF-8 String encoding not supported by JVM", ue);
-            }
-        }
+            => IsLdifSafe(str.ToUtf8Bytes());
 
         /* **************UTF-8 Validation methods and members*******************
         * The following text is taken from draft-yergeau-rfc2279bis-02 and explains

--- a/src/Novell.Directory.Ldap.NETStandard/Utilclass/Base64.cs
+++ b/src/Novell.Directory.Ldap.NETStandard/Utilclass/Base64.cs
@@ -148,7 +148,6 @@ namespace Novell.Directory.Ldap.Utilclass
         /// <returns>
         ///     a String containing the base64 encoded data.
         /// </returns>
-        [CLSCompliant(false)]
         public static string Encode(byte[] inputBytes)
         {
             int i, j, k;
@@ -253,7 +252,6 @@ namespace Novell.Directory.Ldap.Utilclass
         /// <returns>
         ///     The decoded byte array.
         /// </returns>
-        [CLSCompliant(false)]
         public static byte[] Decode(string encodedString)
         {
             var c = new char[encodedString.Length];
@@ -271,7 +269,6 @@ namespace Novell.Directory.Ldap.Utilclass
         /// <returns>
         ///     A byte array object containing decoded bytes.
         /// </returns>
-        [CLSCompliant(false)]
         public static byte[] Decode(char[] encodedChars)
         {
             int i, j, k;
@@ -386,7 +383,6 @@ namespace Novell.Directory.Ldap.Utilclass
         /// <returns>
         ///     The decoded byte array.
         /// </returns>
-        [CLSCompliant(false)]
         public static byte[] Decode(StringBuilder encodedSBuf, int start, int end)
         {
             int i, j, k;
@@ -518,7 +514,6 @@ namespace Novell.Directory.Ldap.Utilclass
         /// <returns>
         ///     true if encoding not required for LDIF.
         /// </returns>
-        [CLSCompliant(false)]
         public static bool IsLdifSafe(byte[] bytes)
         {
             var len = bytes.Length;
@@ -698,7 +693,6 @@ namespace Novell.Directory.Ldap.Utilclass
         ///     sequence generates any character that cannot be
         ///     represented as a UCS2 character (Java String).
         /// </returns>
-        [CLSCompliant(false)]
         public static bool IsValidUtf8(byte[] array, bool isUcs2Only)
         {
             var index = 0;

--- a/src/Novell.Directory.Ldap.NETStandard/Utilclass/CharacterTypes.cs
+++ b/src/Novell.Directory.Ldap.NETStandard/Utilclass/CharacterTypes.cs
@@ -38,7 +38,6 @@ namespace Novell.Directory.Ldap.Utilclass
     ///     Specifies the types of Characters.
     /// </summary>
 // [Flags]
-    [CLSCompliant(false)]
     public enum CharacterTypes : byte
     {
         Whitespace = 1,

--- a/src/Novell.Directory.Ldap.NETStandard/Utilclass/RDN.cs
+++ b/src/Novell.Directory.Ldap.NETStandard/Utilclass/RDN.cs
@@ -162,7 +162,6 @@ namespace Novell.Directory.Ldap.Utilclass
         ///     @throws IllegalArgumentException if the application compares a name
         ///     with an OID.
         /// </param>
-        [CLSCompliant(false)]
         public bool Equals(Rdn rdn)
         {
             if (_values.Count != rdn._values.Count)
@@ -256,7 +255,6 @@ namespace Novell.Directory.Ldap.Utilclass
         /// <returns>
         ///     An RDN string.
         /// </returns>
-        [CLSCompliant(false)]
         public string ToString(bool noTypes)
         {
             var length = _types.Count;

--- a/src/Novell.Directory.Ldap.NETStandard/Utilclass/SchemaParser.cs
+++ b/src/Novell.Directory.Ldap.NETStandard/Utilclass/SchemaParser.cs
@@ -113,7 +113,7 @@ namespace Novell.Directory.Ldap.Utilclass
                                         var nameList = new ArrayList();
                                         while (st2.NextToken() == '\'')
                                         {
-                                            if ((object)st2.StringValue != null)
+                                            if (st2.StringValue != null)
                                             {
                                                 nameList.Add(st2.StringValue);
                                             }


### PR DESCRIPTION
This is built on top of #65 so it appears bigger than it actually is. Though feel free to merge this and close the other one to have the changes in one go.

* Remove Encoding.GetEncoding("utf-8") - this is clearly a holdover from Java and leads to some unneccesary conversions from character srrays to strings to bytes or similar. We have Encoding.UTF8, so this changes those calls to use an Extension Method

* Remove usages of [CLSCompliantAttribute](https://docs.microsoft.com/en-us/dotnet/api/system.clscompliantattribute?redirectedfrom=MSDN&view=netframework-4.7.2). I get the idea behind this attribute back in the early Mono and ".net is an ECMA Standard" days, but I don't think there's any actual real world use for this. Especially since a lot of the important APIs (previously using sbyte[]) were marked CLSCompliant(false) anyway. After the refactor from sbyte[] to byte[] they would actually be CLSCompliant, but well, the attribute is just a source for unneccessary warnings and I doubt that future code will even consider adding it to non-compliant methods. It's just clutter.