### PR TITLE
Handle IPv4 separately then IPv6

### DIFF
--- a/src/Novell.Directory.Ldap.NETStandard/LdapConnection.cs
+++ b/src/Novell.Directory.Ldap.NETStandard/LdapConnection.cs
@@ -910,18 +910,24 @@ namespace Novell.Directory.Ldap
                 {
                     var specifiedPort = port;
                     var address = hostList.NextToken();
-                    var colonIndex = address.IndexOf(':'); // after the colon is the port
-                    if (colonIndex != -1 && colonIndex + 1 != address.Length)
+
+                    if (address.Split(':').Length <= 2)
                     {
-                        // parse Port out of address
-                        try
+                        // IPv4 format
+                        var colonIndex = address.LastIndexOf(':'); //after the colon is the port
+
+                        if (colonIndex != -1 && colonIndex + 1 != address.Length)
                         {
-                            specifiedPort = int.Parse(address.Substring(colonIndex + 1));
-                            address = address.Substring(0, colonIndex - 0);
-                        }
-                        catch (Exception e)
-                        {
-                            throw new ArgumentException(ExceptionMessages.InvalidAddress, e);
+                            //parse Port out of address
+                            try
+                            {
+                                specifiedPort = int.Parse(address.Substring(colonIndex + 1));
+                                address = address.Substring(0, colonIndex - 0);
+                            }
+                            catch (Exception e)
+                            {
+                                throw new ArgumentException(ExceptionMessages.InvalidAddress, e);
+                            }
                         }
                     }
 


### PR DESCRIPTION
Partial fix for Issue #78.

This is only to address part of the problem mentionned by @LexMelnikov in #78 where the IPv6 format isn't supported as we are parsing the address to find out the port number. However, in IPv6 using ":" after the address to specify the port isn't supported.

https://github.com/dsbenghe/Novell.Directory.Ldap.NETStandard/blob/72230ea4f6686062ed74f6a8ae9ab91524ffbead/src/Novell.Directory.Ldap.NETStandard/LdapConnection.cs#L913