### PR TITLE
Enable local certificate validation callbacks. 

### DIFF
--- a/src/Novell.Directory.Ldap.NETStandard/LdapConnection.cs
+++ b/src/Novell.Directory.Ldap.NETStandard/LdapConnection.cs
@@ -1472,9 +1472,16 @@ namespace Novell.Directory.Ldap
 
         public event RemoteCertificateValidationCallback UserDefinedServerCertValidationDelegate
         {
-            add => Connection.OnCertificateValidation += value;
+            add => Connection.OnRemoteCertificateValidation += value;
 
-            remove => Connection.OnCertificateValidation -= value;
+            remove => Connection.OnRemoteCertificateValidation -= value;
+        }
+
+        public event LocalCertificateSelectionCallback UserDefinedClientCertSelectionDelegate
+        {
+            add => Connection.OnLocalCertificateSelection += value;
+
+            remove => Connection.OnLocalCertificateSelection -= value;
         }
 
         /*


### PR DESCRIPTION
Allows client to attach certificates.

This has been tested using a pfx file and has succeeded in connecting, binding & searching a remote secure LDAP server