### PR TITLE
Always dispose _sock and _socket if and only if they have been set

### DIFF
--- a/src/Novell.Directory.Ldap.NETStandard/Connection.cs
+++ b/src/Novell.Directory.Ldap.NETStandard/Connection.cs
@@ -864,14 +864,8 @@ namespace Novell.Directory.Ldap
                     {
                         _inStream?.Dispose();
                         _outStream?.Dispose();
-                        if (Ssl)
-                        {
-                            _sock.Dispose();
-                        }
-                        else
-                        {
-                            _socket.Dispose();
-                        }
+                        _sock?.Dispose();
+                        _socket?.Dispose();
                     }
                     catch (IOException)
                     {


### PR DESCRIPTION
Fix for issue #108 