### PR TITLE
Prevents dns lookup if IP is passed to Connect

### DIFF
--- a/src/Novell.Directory.Ldap.NETStandard/Connection.cs
+++ b/src/Novell.Directory.Ldap.NETStandard/Connection.cs
@@ -530,10 +530,14 @@ namespace Novell.Directory.Ldap
                     {
                         Host = host;
                         Port = port;
-                        var ipAddresses = Dns.GetHostAddressesAsync(host).Result;
-                        var ipAddress = ipAddresses.First(ip =>
-                            ip.AddressFamily == AddressFamily.InterNetwork ||
-                            ip.AddressFamily == AddressFamily.InterNetworkV6);
+
+                        if (!IPAddress.TryParse(host, out IPAddress ipAddress))
+                        {
+                            var ipAddresses = Dns.GetHostAddressesAsync(host).Result;
+                            ipAddress = ipAddresses.First(ip =>
+                                ip.AddressFamily == AddressFamily.InterNetwork ||
+                                ip.AddressFamily == AddressFamily.InterNetworkV6);
+                        }
 
                         if (Ssl)
                         {


### PR DESCRIPTION
This PR adds a check to `Connection.Connect(string host, int port, int semaphoreId)` to determine if `host` is already an IP address. In the case that `host` is an IP, then skip the DNS lookup.

I have a use case in which I am using an IP address specifically to prevent a DNS lookup. In my case, a fallback DNS server is expected to be down. If a DNS lookup occurs the DNS timeout must elapse before continuing with the LDAP connection. In my case this is causing the connection to take around 8 seconds. Skipping the DNS lookup in the case that an IP is provided fixes the issue.

Thanks.