### PR TITLE
Avoid unnecessary async calls

### DIFF
--- a/src/Novell.Directory.Ldap.NETStandard/Connection.cs
+++ b/src/Novell.Directory.Ldap.NETStandard/Connection.cs
@@ -543,7 +543,13 @@ namespace Novell.Directory.Ldap
                         {
                             _sock = new Socket(ipAddress.AddressFamily, SocketType.Stream, ProtocolType.IP);
                             var ipEndPoint = new IPEndPoint(ipAddress, port);
-                            _sock.ConnectAsync(ipEndPoint).WaitAndUnwrap(ConnectionTimeout);
+
+                            //WaitAndUnwrap creates unnecessary threads if ConnectionTimeout is zero which
+                            //can impact performance.  Prefer the sync method call to avoid the overhead
+                            if (ConnectionTimeout != 0)
+                                _sock.ConnectAsync(ipEndPoint).WaitAndUnwrap(ConnectionTimeout);
+                            else
+                                _sock.Connect(ipEndPoint);
 
                             var sslstream = new SslStream(
                                 new NetworkStream(_sock, true),


### PR DESCRIPTION
In cases where we don't specify a timeout, WaitAndUnwrap serves no purpose (i.e. it behaves in the same way as the blocking call) and allocates extra threads that negatively impact performance.

The code now prefers the sync call when  is unset to avoid the extra threads