### PR TITLE
Making Sasl Bind async for advanced Sasl clients

### DIFF
--- a/src/Novell.Directory.Ldap.NETStandard/LdapConnection.Sasl.cs
+++ b/src/Novell.Directory.Ldap.NETStandard/LdapConnection.Sasl.cs
@@ -104,7 +104,7 @@ namespace Novell.Directory.Ldap
                     byte[] clientResponse = null;
                     if (saslClient.HasInitialResponse)
                     {
-                        clientResponse = saslClient.EvaluateChallenge(Array.Empty<byte>());
+                        clientResponse = await saslClient.EvaluateChallengeAsync(Array.Empty<byte>());
                     }
 
                     while (!saslClient.IsComplete)
@@ -115,11 +115,11 @@ namespace Novell.Directory.Ldap
 
                             if (replyBuf != null)
                             {
-                                clientResponse = saslClient.EvaluateChallenge(replyBuf);
+                                clientResponse = await saslClient.EvaluateChallengeAsync(replyBuf);
                             }
                             else
                             {
-                                clientResponse = saslClient.EvaluateChallenge(Array.Empty<byte>());
+                                clientResponse = await saslClient.EvaluateChallengeAsync(Array.Empty<byte>());
                             }
                         }
                         catch (Exception ex)

--- a/src/Novell.Directory.Ldap.NETStandard/Sasl/Clients/BaseSaslClient.cs
+++ b/src/Novell.Directory.Ldap.NETStandard/Sasl/Clients/BaseSaslClient.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections;
+using System.Threading.Tasks;
 
 namespace Novell.Directory.Ldap.Sasl.Clients
 {
@@ -21,7 +22,7 @@ namespace Novell.Directory.Ldap.Sasl.Clients
         public abstract string MechanismName { get; }
         public abstract bool HasInitialResponse { get; }
         public abstract bool IsComplete { get; }
-        public abstract byte[] EvaluateChallenge(byte[] challenge);
+        public abstract Task<byte[]> EvaluateChallengeAsync(byte[] challenge);
 
         public void Dispose()
         {

--- a/src/Novell.Directory.Ldap.NETStandard/Sasl/Clients/CramMD5Client.cs
+++ b/src/Novell.Directory.Ldap.NETStandard/Sasl/Clients/CramMD5Client.cs
@@ -1,4 +1,5 @@
 ﻿using System.Security.Cryptography;
+using System.Threading.Tasks;
 
 namespace Novell.Directory.Ldap.Sasl.Clients
 {
@@ -37,7 +38,7 @@ namespace Novell.Directory.Ldap.Sasl.Clients
             _currentState = State.Disposed;
         }
 
-        public override byte[] EvaluateChallenge(byte[] challenge)
+        public async override Task<byte[]> EvaluateChallengeAsync(byte[] challenge)
         {
             byte[] response = null;
             switch (_currentState)

--- a/src/Novell.Directory.Ldap.NETStandard/Sasl/Clients/DigestMD5Client.cs
+++ b/src/Novell.Directory.Ldap.NETStandard/Sasl/Clients/DigestMD5Client.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Linq;
 using System.Security.Cryptography;
+using System.Threading.Tasks;
 
 namespace Novell.Directory.Ldap.Sasl.Clients
 {
@@ -66,7 +67,7 @@ namespace Novell.Directory.Ldap.Sasl.Clients
             _currentState = State.Disposed;
         }
 
-        public override byte[] EvaluateChallenge(byte[] challenge)
+        public async override Task<byte[]> EvaluateChallengeAsync(byte[] challenge)
         {
             byte[] response = null;
             switch (_currentState)

--- a/src/Novell.Directory.Ldap.NETStandard/Sasl/Clients/PlainClient.cs
+++ b/src/Novell.Directory.Ldap.NETStandard/Sasl/Clients/PlainClient.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Threading.Tasks;
 
 namespace Novell.Directory.Ldap.Sasl.Clients
 {
@@ -37,7 +38,7 @@ namespace Novell.Directory.Ldap.Sasl.Clients
             _password = saslRequest.Credentials;
         }
 
-        public override byte[] EvaluateChallenge(byte[] challenge)
+        public async override Task<byte[]> EvaluateChallengeAsync(byte[] challenge)
         {
             byte[] response = null;
             switch (_currentState)

--- a/src/Novell.Directory.Ldap.NETStandard/Sasl/ISaslClient.cs
+++ b/src/Novell.Directory.Ldap.NETStandard/Sasl/ISaslClient.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Threading.Tasks;
 
 namespace Novell.Directory.Ldap.Sasl
 {
@@ -8,7 +9,7 @@ namespace Novell.Directory.Ldap.Sasl
 
         bool HasInitialResponse { get; }
 
-        byte[] EvaluateChallenge(byte[] challenge);
+        Task<byte[]> EvaluateChallengeAsync(byte[] challenge);
 
         bool IsComplete { get; }
     }

--- a/test/Novell.Directory.Ldap.NETStandard.UnitTests/PlainClientTests.cs
+++ b/test/Novell.Directory.Ldap.NETStandard.UnitTests/PlainClientTests.cs
@@ -2,6 +2,7 @@
 using Novell.Directory.Ldap.Sasl.Clients;
 using System;
 using System.Collections.Generic;
+using System.Threading.Tasks;
 using Xunit;
 
 namespace Novell.Directory.Ldap.NETStandard.UnitTests
@@ -29,11 +30,11 @@ namespace Novell.Directory.Ldap.NETStandard.UnitTests
         }
 
         [Fact]
-        public void CreatesChallengeProperly()
+        public async Task CreatesChallengeProperly()
         {
             var request = new SaslPlainRequest(AuthId, Password);
             var client = new PlainClient(request);
-            var result = client.EvaluateChallenge(Array.Empty<byte>());
+            var result = await client.EvaluateChallengeAsync(Array.Empty<byte>());
             Assert.Equal(ExpectedResponse, result);
         }
     }

--- a/test/Novell.Directory.Ldap.NETStandard.UnitTests/TestSaslClient.cs
+++ b/test/Novell.Directory.Ldap.NETStandard.UnitTests/TestSaslClient.cs
@@ -1,5 +1,6 @@
 ﻿using Novell.Directory.Ldap.Sasl;
 using System.Collections.Generic;
+using System.Threading.Tasks;
 
 namespace Novell.Directory.Ldap.NETStandard.UnitTests
 {
@@ -36,7 +37,7 @@ namespace Novell.Directory.Ldap.NETStandard.UnitTests
         {
         }
 
-        public byte[] EvaluateChallenge(byte[] challenge)
+        public async Task<byte[]> EvaluateChallengeAsync(byte[] challenge)
         {
             return challenge;
         }


### PR DESCRIPTION
Ideally, I believe all Bind methods should be async (or at least have an async variant), but for implementing some custom based Sasl clients which acts asynchronously (aka receive data to feed via EvaluateChallenge asynchronously - ie via a network, for example) the async is really a must have.
This might break a bit backward compatibility (because of interface changes), but I tried to make the port to be as harmless as possible (at least I hope). I kept all the old synchronized methods as is without changing their behaviour (I believe).