### PR TITLE
Huge performance increase in filter parsing

### DIFF
--- a/src/Novell.Directory.Ldap.NETStandard/Rfc2251/RfcFilter.cs
+++ b/src/Novell.Directory.Ldap.NETStandard/Rfc2251/RfcFilter.cs
@@ -1306,13 +1306,13 @@ namespace Novell.Directory.Ldap.Rfc2251
                     }
                     else
                     {
-                        if (_filter.Substring(_offset).StartsWith(":="))
+                        if (_filter.StartsWithStringAtOffset(":=", _offset))
                         {
                             throw new LdapLocalException(ExceptionMessages.NoMatchingRule, LdapException.FilterError);
                         }
 
-                        if (_filter.Substring(_offset).StartsWith("::=") ||
-                            _filter.Substring(_offset).StartsWith(":::="))
+                        if (_filter.StartsWithStringAtOffset("::=", _offset) ||
+                            _filter.StartsWithStringAtOffset(":::=", _offset))
                         {
                             throw new LdapLocalException(
                                 ExceptionMessages.NoDnNorMatchingRule,
@@ -1324,7 +1324,7 @@ namespace Novell.Directory.Ldap.Rfc2251
                         var sb = new StringBuilder();
 
                         while (delims.IndexOf(_filter[_offset]) == -1 &&
-                               _filter.Substring(_offset).StartsWith(":=") == false)
+                               _filter.StartsWithStringAtOffset(":=", _offset) == false)
                         {
                             sb.Append(_filter[_offset++]);
                         }
@@ -1386,22 +1386,22 @@ namespace Novell.Directory.Ldap.Rfc2251
                     }
 
                     int ret;
-                    if (_filter.Substring(_offset).StartsWith(">="))
+                    if (_filter.StartsWithStringAtOffset(">=", _offset))
                     {
                         _offset += 2;
                         ret = GreaterOrEqual;
                     }
-                    else if (_filter.Substring(_offset).StartsWith("<="))
+                    else if (_filter.StartsWithStringAtOffset("<=", _offset))
                     {
                         _offset += 2;
                         ret = LessOrEqual;
                     }
-                    else if (_filter.Substring(_offset).StartsWith("~="))
+                    else if (_filter.StartsWithStringAtOffset("~=", _offset))
                     {
                         _offset += 2;
                         ret = ApproxMatch;
                     }
-                    else if (_filter.Substring(_offset).StartsWith(":="))
+                    else if (_filter.StartsWithStringAtOffset(":=", _offset))
                     {
                         _offset += 2;
                         ret = ExtensibleMatch;

--- a/src/Novell.Directory.Ldap.NETStandard/Utilclass/StringExtensions.cs
+++ b/src/Novell.Directory.Ldap.NETStandard/Utilclass/StringExtensions.cs
@@ -1,35 +1,3 @@
-/******************************************************************************
-* The MIT License
-* Copyright (c) 2003 Novell Inc.,  www.novell.com
-*
-* Permission is hereby granted, free of charge, to any person obtaining  a copy
-* of this software and associated documentation files (the Software), to deal
-* in the Software without restriction, including  without limitation the rights
-* to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-* copies of the Software, and to  permit persons to whom the Software is
-* furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included in
-* all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED AS IS, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-* IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-* OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-* SOFTWARE.
-*******************************************************************************/
-
-//
-// Novell.Directory.Ldap.Utilclass.TokenType.cs
-//
-// Author:
-//   Sunil Kumar (Sunilk@novell.com)
-//
-// (C) 2003 Novell, Inc (http://www.novell.com)
-//
-
 using System;
 
 namespace Novell.Directory.Ldap.Utilclass

--- a/src/Novell.Directory.Ldap.NETStandard/Utilclass/StringExtensions.cs
+++ b/src/Novell.Directory.Ldap.NETStandard/Utilclass/StringExtensions.cs
@@ -9,8 +9,12 @@ namespace Novell.Directory.Ldap.Utilclass
         /// </summary>
         public static bool StartsWithStringAtOffset(this string baseString, string value, int offset)
         {
-            if (value == null) throw new ArgumentNullException(nameof(value));
-            if (offset < 0) throw new ArgumentOutOfRangeException(nameof(offset));
+            if (value == null) 
+                throw new ArgumentNullException(nameof(value));
+            if (offset < 0) 
+                throw new ArgumentOutOfRangeException(nameof(offset));
+            if (offset > baseString.Length) 
+                throw new ArgumentOutOfRangeException(nameof(offset), "offset cannot be larger than length of string");
 
             if (offset + value.Length > baseString.Length)
             {

--- a/src/Novell.Directory.Ldap.NETStandard/Utilclass/StringExtensions.cs
+++ b/src/Novell.Directory.Ldap.NETStandard/Utilclass/StringExtensions.cs
@@ -1,0 +1,61 @@
+/******************************************************************************
+* The MIT License
+* Copyright (c) 2003 Novell Inc.,  www.novell.com
+*
+* Permission is hereby granted, free of charge, to any person obtaining  a copy
+* of this software and associated documentation files (the Software), to deal
+* in the Software without restriction, including  without limitation the rights
+* to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+* copies of the Software, and to  permit persons to whom the Software is
+* furnished to do so, subject to the following conditions:
+*
+* The above copyright notice and this permission notice shall be included in
+* all copies or substantial portions of the Software.
+*
+* THE SOFTWARE IS PROVIDED AS IS, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+* IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+* OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+* SOFTWARE.
+*******************************************************************************/
+
+//
+// Novell.Directory.Ldap.Utilclass.TokenType.cs
+//
+// Author:
+//   Sunil Kumar (Sunilk@novell.com)
+//
+// (C) 2003 Novell, Inc (http://www.novell.com)
+//
+
+using System;
+
+namespace Novell.Directory.Ldap.Utilclass
+{
+    public static class StringExtensions
+    {
+        /// <summary>
+        /// Replaces string.Substring(offset).StartsWith(value) and avoids memory allocations
+        /// </summary>
+        public static bool StartsWithStringAtOffset(this string baseString, string value, int offset)
+        {
+            if (value == null) throw new ArgumentNullException(nameof(value));
+            if (offset < 0) throw new ArgumentOutOfRangeException(nameof(offset));
+
+            if (offset + value.Length > baseString.Length)
+            {
+                return false;
+            }
+
+            for (int i = 0; i < value.Length; i++)
+            {
+                if (baseString[offset + i] != value[i])
+                    return false;
+            }
+
+            return true;
+        }
+    }
+}

--- a/test/Novell.Directory.Ldap.NETStandard.UnitTests/StringExtensionTests.cs
+++ b/test/Novell.Directory.Ldap.NETStandard.UnitTests/StringExtensionTests.cs
@@ -1,0 +1,72 @@
+﻿using Novell.Directory.Ldap.Utilclass;
+using System;
+using System.Collections.Generic;
+using Xunit;
+
+namespace Novell.Directory.Ldap.NETStandard.UnitTests
+{
+    public class StringExtensionTests
+    {
+        [Theory]
+        [MemberData(nameof(DataSuccess))]
+        public void StartsWithStringAtOffset_Success(string baseString, string searchString, int offset)
+        {
+            Assert.Equal(baseString.StartsWithStringAtOffset(searchString, offset), baseString.Substring(offset).StartsWith(searchString));
+        }
+
+        public static IEnumerable<object[]> DataSuccess =>
+        new List<object[]>
+        {
+            // Empty strings
+            new object[] { "", "", 0 },
+            new object[] { "", "test", 0 },
+            new object[] { "test", "", 0 }, 
+            new object[] { "test", "", 4 }, 
+
+            // Complete valid range
+            new object[] { "abcd", "ab", 0 },
+            new object[] { "abcd", "ab", 1 },
+            new object[] { "abcd", "ab", 2 },
+            new object[] { "abcd", "ab", 4 },
+
+            // same length
+            new object[] { "abcd", "abcd", 0 }, 
+            new object[] { "abcd", "abcd", 1 },
+
+            // Searchstring longer than baseString
+            new object[] { "ab", "abcd", 0 }, 
+
+            // Unicode
+            new object[] { "大象牙膏", "象牙", 0 },
+            new object[] { "大象牙膏", "象牙", 1 },
+            new object[] { "大象牙膏", "象牙", 2 },
+            new object[] { "大象牙膏", "象牙", 3 },
+            new object[] { "大象牙膏", "象牙", 4 },
+            new object[] { "зубная паста слона", "аста", 8 }
+        };
+
+        [Theory]
+        [MemberData(nameof(DataException))]
+        public void StartsWithStringAtOffset_Exception(string baseString, string searchString, int offset)
+        {
+            var substringStartsWithException = Assert.ThrowsAny<Exception>(() => baseString.Substring(offset).StartsWith(searchString));
+            var startsWithStringAtOffsetException = Assert.ThrowsAny<Exception>(() => baseString.StartsWithStringAtOffset(searchString, offset));
+            // Same exception type?
+            Assert.IsType(substringStartsWithException.GetType(), startsWithStringAtOffsetException);
+        }
+
+        public static IEnumerable<object[]> DataException =>
+        new List<object[]>
+        {
+            // Null Argument
+            new object[] {"abcd", null, 0},
+            
+            // Invalid offset
+            new object[] { "abcd", "abcd", 5 },
+            new object[] { "", "abcd", 1 },
+            new object[] { "abcd", "ab", 5 },
+            new object[] { "abcd", "ab", -1 },
+            new object[] { "大象牙膏", "象牙", 5 },
+        };
+    }
+}

--- a/test/Novell.Directory.Ldap.NETStandard.UnitTests/StringExtensionTests.cs
+++ b/test/Novell.Directory.Ldap.NETStandard.UnitTests/StringExtensionTests.cs
@@ -1,6 +1,5 @@
 ﻿using Novell.Directory.Ldap.Utilclass;
 using System;
-using System.Collections.Generic;
 using Xunit;
 
 namespace Novell.Directory.Ldap.NETStandard.UnitTests
@@ -14,36 +13,41 @@ namespace Novell.Directory.Ldap.NETStandard.UnitTests
             Assert.Equal(baseString.StartsWithStringAtOffset(searchString, offset), baseString.Substring(offset).StartsWith(searchString));
         }
 
-        public static IEnumerable<object[]> DataSuccess =>
-        new List<object[]>
+        public static TheoryData<string, string, int> DataSuccess
         {
-            // Empty strings
-            new object[] { "", "", 0 },
-            new object[] { "", "test", 0 },
-            new object[] { "test", "", 0 }, 
-            new object[] { "test", "", 4 }, 
+            get
+            {
+                return new TheoryData<string, string, int>
+                {
+                    // Empty strings
+                    { "", "", 0 },
+                    { "", "test", 0 },
+                    { "test", "", 0 },
+                    { "test", "", 4 },
 
-            // Complete valid range
-            new object[] { "abcd", "ab", 0 },
-            new object[] { "abcd", "ab", 1 },
-            new object[] { "abcd", "ab", 2 },
-            new object[] { "abcd", "ab", 4 },
+                    // Complete valid range
+                    { "abcd", "ab", 0 },
+                    { "abcd", "ab", 1 },
+                    { "abcd", "ab", 2 },
+                    { "abcd", "ab", 4 },
 
-            // same length
-            new object[] { "abcd", "abcd", 0 }, 
-            new object[] { "abcd", "abcd", 1 },
+                    // same length
+                    { "abcd", "abcd", 0 },
+                    { "abcd", "abcd", 1 },
 
-            // Searchstring longer than baseString
-            new object[] { "ab", "abcd", 0 }, 
+                    // Searchstring longer than baseString
+                    { "ab", "abcd", 0 },
 
-            // Unicode
-            new object[] { "大象牙膏", "象牙", 0 },
-            new object[] { "大象牙膏", "象牙", 1 },
-            new object[] { "大象牙膏", "象牙", 2 },
-            new object[] { "大象牙膏", "象牙", 3 },
-            new object[] { "大象牙膏", "象牙", 4 },
-            new object[] { "зубная паста слона", "аста", 8 }
-        };
+                    // Unicode
+                    { "大象牙膏", "象牙", 0 },
+                    { "大象牙膏", "象牙", 1 },
+                    { "大象牙膏", "象牙", 2 },
+                    { "大象牙膏", "象牙", 3 },
+                    { "大象牙膏", "象牙", 4 },
+                    { "зубная паста слона", "аста", 8 }
+                };
+            }
+        }
 
         [Theory]
         [MemberData(nameof(DataException))]
@@ -55,18 +59,23 @@ namespace Novell.Directory.Ldap.NETStandard.UnitTests
             Assert.IsType(substringStartsWithException.GetType(), startsWithStringAtOffsetException);
         }
 
-        public static IEnumerable<object[]> DataException =>
-        new List<object[]>
+        public static TheoryData<string, string, int> DataException
         {
-            // Null Argument
-            new object[] {"abcd", null, 0},
-            
-            // Invalid offset
-            new object[] { "abcd", "abcd", 5 },
-            new object[] { "", "abcd", 1 },
-            new object[] { "abcd", "ab", 5 },
-            new object[] { "abcd", "ab", -1 },
-            new object[] { "大象牙膏", "象牙", 5 },
-        };
+            get
+            {
+                return new TheoryData<string, string, int>
+                {
+                    // Null Argument
+                    { "abcd", null, 0 },
+
+                    // Invalid offset
+                    { "abcd", "abcd", 5 },
+                    { "", "abcd", 1 },
+                    { "abcd", "ab", 5 },
+                    { "abcd", "ab", -1 },
+                    { "大象牙膏", "象牙", 5 },
+                };
+            }
+        }
     }
 }


### PR DESCRIPTION
We are sometimes using large filters to query information about a lot of active directory groups at once (up to 200 groups). When I developed on my windows machine, the performance was alright and I had the response in about 40ms. When I deployed the .NET Core 3.1 Webservice to a linux machine, the duration for one query went **up to one second**. 

After a lot of performance measuring I figured out that the culprit was the huge number of called `_filter.Substring(_offset).StartsWith(...)` while parsing the filter. This code is much less performant on Linux than on Windows. Besides that there are a lot of memory allocations which can be avoided.

So I replaced those lines with an index based method `StartsWithStringAtOffset`, which I implemented as an extension method on string.

I only benchmarked the **constructor of RfcFilter**. The output of BenchmarkDotNet speaks for itself:

### Windows
| Method |       Runtime |        FilterString |          Mean |       Error |     StdDev | Ratio |     Gen 0 |   Gen 1 | Gen 2 |   Allocated |
|------- |-------------- |-------------------- |--------------:|------------:|-----------:|------:|----------:|--------:|------:|------------:|
|    Old |    .NET 4.7.2 | (&((...)p)) [12517] | 17,807.906 us | 105.4075 us | 98.5982 us | 1.000 | 9687.5000 |       - |     - | 44814.69 KB |
|    New |    .NET 4.7.2 | (&((...)p)) [12517] |    120.077 us |   0.3840 us |  0.3592 us | 0.007 |   33.4473 |       - |     - |   154.35 KB |
|        |               |                     |               |             |            |       |           |         |       |             |
|    Old | .NET Core 3.1 | (&((...)p)) [12517] |  4,336.735 us |  66.2438 us | 61.9644 us |  1.00 | 9703.1250 | 23.4375 |     - | 44680.05 KB |
|    New | .NET Core 3.1 | (&((...)p)) [12517] |    111.288 us |   0.4098 us |  0.3834 us |  0.03 |   33.0811 |  5.4932 |     - |   152.32 KB |
|        |               |                     |               |             |            |       |           |         |       |             |
|    Old | .NET Core 5.0 | (&((...)p)) [12517] |  8,095.366 us |  98.9044 us | 92.5152 us |  1.00 | 9703.1250 | 31.2500 |     - | 44680.05 KB |
|    New | .NET Core 5.0 | (&((...)p)) [12517] |    111.475 us |   0.6306 us |  0.5899 us |  0.01 |   33.0811 |  5.4932 |     - |   152.32 KB |
|        |               |                     |               |             |            |       |           |         |       |             |
|    Old |    .NET 4.7.2 |  (&((...)up)) [105] |      7.001 us |   0.0151 us |  0.0141 us |  1.00 |    1.7395 |       - |     - |     8.03 KB |
|    New |    .NET 4.7.2 |  (&((...)up)) [105] |      1.284 us |   0.0040 us |  0.0037 us |  0.18 |    0.4463 |       - |     - |     2.06 KB |
|        |               |                     |               |             |            |       |           |         |       |             |
|    Old | .NET Core 3.1 |  (&((...)up)) [105] |      4.494 us |   0.0176 us |  0.0147 us |  1.00 |    1.7014 |  0.0076 |     - |     7.82 KB |
|    New | .NET Core 3.1 |  (&((...)up)) [105] |      1.187 us |   0.0051 us |  0.0047 us |  0.26 |    0.4406 |  0.0019 |     - |     2.03 KB |
|        |               |                     |               |             |            |       |           |         |       |             |
|    Old | .NET Core 5.0 |  (&((...)up)) [105] |     25.611 us |   0.1260 us |  0.1179 us |  1.00 |    1.6785 |       - |     - |     7.82 KB |
|    New | .NET Core 5.0 |  (&((...)up)) [105] |      1.138 us |   0.0055 us |  0.0051 us |  0.04 |    0.4406 |  0.0019 |     - |     2.03 KB |

Interestingly the performance was even worse on .NET 5 compared to .NET Core 3.1 despite all the performance improvements in the framework.

### Linux (only .NET Core 3.1)

| Method |        FilterString |           Mean |         Error |        StdDev | Ratio |     Gen 0 |  Gen 1 | Gen 2 |   Allocated |
|------- |-------------------- |---------------:|--------------:|--------------:|------:|----------:|-------:|------:|------------:|
|    Old | (&((...)p)) [11853] | 473,058.908 us | 4,711.7555 us | 4,176.8485 us | 1.000 | 7000.0000 |      - |     - | 34547.02 KB |
|    New | (&((...)p)) [11853] |     120.620 us |     1.1843 us |     1.0498 us | 0.000 |   28.8086 | 4.0283 |     - |   132.66 KB |
|        |                     |                |               |               |       |           |        |       |             |
|    Old |  (&((...)up)) [109] |       5.076 us |     0.0330 us |     0.0276 us |  1.00 |    1.7395 | 0.0076 |     - |     8.02 KB |
|    New |  (&((...)up)) [109] |       1.520 us |     0.0030 us |     0.0024 us |  0.30 |    0.4444 | 0.0019 |     - |     2.05 KB |

The BenchmarkDotNet for windows code was

```csharp
[SimpleJob(RuntimeMoniker.Net472)]
[SimpleJob(RuntimeMoniker.NetCoreApp31)]
[SimpleJob(RuntimeMoniker.NetCoreApp50)]
[MemoryDiagnoser]
public class Benchmark
{
    public IEnumerable<string> FilterStrings => new List<string>
    {
        "(&(|(distinguishedName=CN=My Group,OU=Central,OU=Groups,DC=domain,DC=example,DC=com))(objectClass=group))",
        // Search for 150 groups
        $"(&(|{string.Join("", Enumerable.Range(1, 150).Select(n => $"CN=My Group {n},OU=Central,OU=Groups,DC=domain,DC=example,DC=com").Select(g => $"(distinguishedName={g})"))})(objectClass=group))"
    };

    [ParamsSource(nameof(FilterStrings))]
    public string FilterString;

    [Benchmark(Baseline = true)]
    public void Old()
    {
        new RfcFilterCurrent(FilterString);
    }

    [Benchmark]
    public void New()
    {
        new RfcFilter(FilterString);
    }
}
```

The code for linux was pretty similar but I only ran it with `[SimpleJob(RuntimeMoniker.NetCoreApp31)]` and the filter contained other groups, hence the small difference in size.