### PR TITLE
LdapPagedResultsControl.cs & PagedResultsControlHandler.cs

### DIFF
--- a/src/Novell.Directory.Ldap.NETStandard/Controls/LdapPagedResultsControl.cs
+++ b/src/Novell.Directory.Ldap.NETStandard/Controls/LdapPagedResultsControl.cs
@@ -1,0 +1,106 @@
+using System;
+using JetBrains.Annotations;
+using Novell.Directory.Ldap.Asn1;
+
+namespace Novell.Directory.Ldap.Controls
+{
+    /// <summary>
+    /// An LDAP client application that needs to control the rate at which results are returned
+    /// MAY specify on the searchRequest a <see cref="LdapPagedResultsControl"/> with size set
+    /// to the desired page size and cookie set to the zero-length string. The page size specified
+    /// MAY be greater than zero and less than the sizeLimit value specified in the
+    /// searchRequest. [RFC 2696]
+    /// </summary>
+	public class LdapPagedResultsControl: LdapControl
+    {
+        private const string RequestOid = "1.2.840.113556.1.4.319";
+        private const string DecodedNotInteger = "Decoded value is not an integer, but should be";
+        private const string DecodedNotOctetString = "Decoded value is not an octet string, but should be";
+
+        private static readonly string DecodedNotSequence = $"Failed to construct {nameof(LdapPagedResultsControl)}: " +
+                                                            $"provided values might not be decoded as {nameof(Asn1Sequence)}";
+        private Asn1Sequence _request;
+        
+        static LdapPagedResultsControl()
+        {
+            try
+            {
+                Register(RequestOid, typeof(LdapPagedResultsControl));
+            }
+            catch (Exception ex)
+            {
+                Logger.Log.LogWarning($"Failed to bind oid <{RequestOid}> to control <{nameof(LdapPagedResultsControl)}>", ex);
+            }
+        }
+
+        /// <summary>
+        /// Constructs <see cref="LdapPagedResultsControl"/> control.
+        /// </summary>
+        /// <param name="size"><see cref="LdapPagedResultsControl.Size"/></param>
+        /// <param name="cookie"><see cref="LdapPagedResultsControl.Cookie"/></param>
+        public LdapPagedResultsControl(int size, [CanBeNull] byte[] cookie) : base(RequestOid, true, null)
+        {
+            Size = size;
+            Cookie = cookie ?? GetEmptyCookie;
+            BuildTypedPagedRequest();
+            // ReSharper disable once VirtualMemberCallInConstructor
+            SetValue(_request.GetEncoding(new LberEncoder()));
+        }
+        
+        [UsedImplicitly]
+        public LdapPagedResultsControl(string oid, bool critical, byte[] values) : base(oid, critical, values)
+        {
+            var lberDecoder = new LberDecoder();
+            if (lberDecoder == null) throw new InvalidOperationException($"Failed to build {nameof(LberDecoder)}");
+            
+            var asn1Object = lberDecoder.Decode(values);
+            if (!(asn1Object is Asn1Sequence)) throw new InvalidCastException(DecodedNotSequence);
+            
+            var size = ((Asn1Structured) asn1Object).get_Renamed(0);
+            if (!(size is Asn1Integer integerSize)) throw new InvalidOperationException(DecodedNotInteger);
+            Size = integerSize.IntValue();
+            
+            var cookie = ((Asn1Structured) asn1Object).get_Renamed(1);
+            if (!(cookie is Asn1OctetString octetCookie)) throw new InvalidOperationException(DecodedNotOctetString);
+            Cookie = octetCookie.ByteValue();
+        }
+
+        /// <summary>
+        /// REQUEST: An LDAP client application that needs to control the rate at which
+        /// results are returned MAY specify on the searchRequest a
+        /// pagedResultsControl with size set to the desired page siz
+        ///
+        /// RESPONSE: Each time the server returns a set of results to the client when
+        /// processing a search request containing the pagedResultsControl, the
+        /// server includes the pagedResultsControl control in the
+        /// searchResultDone message. In the control returned to the client, the
+        /// size MAY be set to the server’s estimate of the total number of
+        /// entries in the entire result set. Servers that cannot provide such an
+        /// estimate MAY set this size to zero (0).
+        /// </summary>
+        public int Size { get; }
+
+        /// <summary>
+        /// INITIAL REQUEST: empty cookie
+        ///
+        /// CONSEQUENT REQUEST: cookie from previous response
+        ///
+        /// RESPONSE: The cookie MUST be set to an empty value if there are no more
+        /// entries to return (i.e., the page of search results returned was the last),
+        /// or, if there are more entries to return, to an octet string of the server’s
+        /// choosing, used to resume the search.
+        /// </summary>
+        public byte[] Cookie { get; }
+
+        public bool IsEmptyCookie() => Cookie == null || Cookie.Length == 0;
+
+        public static byte[] GetEmptyCookie => Array.Empty<byte>();
+
+        private void BuildTypedPagedRequest()
+        {
+            _request = new Asn1Sequence(2);
+            _request.Add(new Asn1Integer(Size));
+            _request.Add(new Asn1OctetString(Cookie));
+        }
+    }
+}

--- a/src/Novell.Directory.Ldap.NETStandard/Novell.Directory.Ldap.NETStandard.csproj
+++ b/src/Novell.Directory.Ldap.NETStandard/Novell.Directory.Ldap.NETStandard.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <Description>
-    LDAP client library - .NET Standard 1.3/2.0/2.1 and .NET5 - compatible .NET platforms: .NET5, .NET Core >= 1.0, .NET Framework >= 4.6, Universal Windows Platform, Xamarin. Works with any LDAP server (including Microsoft Active Directory - AD)
+    LDAP client library - .NET Standard 1.3/2.0/2.1 and .NET5 - compatible .NET platforms: .NET5, .NET Core &gt;= 1.0, .NET Framework &gt;= 4.6, Universal Windows Platform, Xamarin. Works with any LDAP server (including Microsoft Active Directory - AD)
     </Description>
     <Summary>.NET Standard LDAP client library</Summary>
     <VersionPrefix>4.0.0-alpha2</VersionPrefix>
@@ -65,6 +65,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
+    <PackageReference Include="JetBrains.Annotations" Version="2020.3.0" />
     <!--
     <PackageReference Include="Roslynator.Analyzers" Version="2.3.0">
       <PrivateAssets>all</PrivateAssets>

--- a/src/Novell.Directory.Ldap.NETStandard/Utilclass/PagedResultsControlHandler.cs
+++ b/src/Novell.Directory.Ldap.NETStandard/Utilclass/PagedResultsControlHandler.cs
@@ -1,0 +1,124 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using System.Threading.Tasks;
+using JetBrains.Annotations;
+using Novell.Directory.Ldap.Controls;
+
+namespace Novell.Directory.Ldap.Utilclass
+{
+    /// <summary>
+    /// Provides utility method to load and map all desired entries via n requests
+    /// with <see cref="LdapPagedResultsControl"/>.
+    /// </summary>
+    public class PagedResultsControlHandler<T>
+    {
+        private readonly Func<LdapEntry, T> _converter;
+
+        public PagedResultsControlHandler([NotNull] Func<LdapEntry, T> converter)
+        {
+            _converter = converter ?? throw new ArgumentNullException(nameof(converter));
+        }
+
+        public async Task<List<T>> LoadAllPagedResults([NotNull] SearchOptions options)
+        {
+            if (options == null) throw new ArgumentNullException(nameof(options));
+            using (var ldapConnection = await ConnectAsync(options))
+            {
+                var searchResult = new List<T>();
+                var isNextPageAvailable = PrepareForNextPage(ldapConnection, null, options.ResultPageSize, true);
+                while (isNextPageAvailable)
+                {
+                    var responseControls = await RetrievePageAsync(ldapConnection, options, searchResult);
+                    isNextPageAvailable = PrepareForNextPage(ldapConnection, responseControls, options.ResultPageSize, false);
+                }
+
+                return searchResult;
+            }
+        }
+
+        private static async Task<LdapConnection> ConnectAsync([NotNull] SearchOptions options)
+        {
+            if (options == null) throw new ArgumentNullException(nameof(options));
+
+            var ldapConnection = new LdapConnection {SecureSocketLayer = false};
+            await ldapConnection.ConnectAsync(options.Host, options.Port);
+            await ldapConnection.BindAsync(options.ProtocolVersion, options.Login, options.Password);
+            Debug.WriteLine($@"Connected to <{options.Host}:{options.Port}> as <{options.Login}>");
+            return ldapConnection;
+        }
+
+        private static bool PrepareForNextPage([NotNull] LdapConnection ldapConnection, [CanBeNull] LdapControl[] pageResponseControls, int pageSize,
+            bool isInitialCall)
+        {
+            if (ldapConnection == null) throw new ArgumentNullException(nameof(ldapConnection));
+            if (pageSize <= 0) throw new ArgumentOutOfRangeException(nameof(pageSize));
+
+            var cookie = LdapPagedResultsControl.GetEmptyCookie;
+            if (!isInitialCall)
+            {
+                var pagedResultsControl = (LdapPagedResultsControl) pageResponseControls?.FirstOrDefault(x => x is LdapPagedResultsControl);
+                if (pagedResultsControl == null)
+                {
+                    Debug.WriteLine($"Failed to find <{nameof(LdapPagedResultsControl)}>. Searching is abruptly stopped");
+                    return false;
+                }
+
+                // server signaled end of result set
+                if (pagedResultsControl.IsEmptyCookie()) return false;
+                cookie = pagedResultsControl.Cookie;
+            }
+
+            ApplyPagedResultsControl(ldapConnection, pageSize, cookie);
+            return true;
+        }
+
+        private static void ApplyPagedResultsControl([NotNull] LdapConnection connection, int pageSize, [CanBeNull] byte[] cookie)
+        {
+            if (connection == null) throw new ArgumentNullException(nameof(connection));
+
+            var ldapPagedControl = new LdapPagedResultsControl(pageSize, cookie);
+            var searchConstraints = connection.SearchConstraints;
+            searchConstraints.BatchSize = 0;
+            searchConstraints.SetControls(ldapPagedControl);
+            connection.Constraints = searchConstraints;
+        }
+
+        private async Task<LdapControl[]> RetrievePageAsync([NotNull] LdapConnection ldapConnection, [NotNull] SearchOptions options,
+            [NotNull] List<T> mappedResultsAccumulator)
+        {
+            if (ldapConnection == null) throw new ArgumentNullException(nameof(ldapConnection));
+            if (options == null) throw new ArgumentNullException(nameof(options));
+            if (mappedResultsAccumulator == null) throw new ArgumentNullException(nameof(mappedResultsAccumulator));
+
+            var searchResults = await ldapConnection.SearchAsync
+            (
+                options.SearchBase,
+                LdapConnection.ScopeSub,
+                options.Filter,
+                options.TargetAttributes,
+                false,
+                (LdapSearchConstraints) null
+            );
+
+            while (searchResults.HasMore())
+            {
+                try
+                {
+                    var nextEntry = searchResults.Next();
+                    var mappedEntry = _converter.Invoke(nextEntry);
+                    mappedResultsAccumulator.Add(mappedEntry);
+                }
+                catch (LdapException ex)
+                {
+                    // you may want to turn referral chasing on
+                    if (ex is LdapReferralException) continue;
+                    throw new InvalidOperationException("Failed to proceed to the next search result", ex);
+                }
+            }
+
+            return ((LdapSearchResults) searchResults).ResponseControls;
+        }
+    }
+}

--- a/src/Novell.Directory.Ldap.NETStandard/Utilclass/SearchOptions.cs
+++ b/src/Novell.Directory.Ldap.NETStandard/Utilclass/SearchOptions.cs
@@ -1,0 +1,32 @@
+using System;
+using JetBrains.Annotations;
+
+namespace Novell.Directory.Ldap.Utilclass
+{
+	public class SearchOptions
+	{
+		public readonly string Host;
+		public readonly int Port;
+		public readonly string Login;
+		public readonly string Password;
+		public readonly string SearchBase;
+		public readonly string Filter;
+		public readonly int ProtocolVersion;
+		public readonly int ResultPageSize;
+		public readonly string[] TargetAttributes;
+
+		public SearchOptions([NotNull] string host, int port, [NotNull] string login, [NotNull] string password, [NotNull] string searchBase,
+			[NotNull] string filter, int protocolVersion, int resultPageSize, [NotNull] string[] targetAttribute)
+		{
+			Host = host ?? throw new ArgumentNullException(nameof(host));
+			Port = port;
+			Login = login ?? throw new ArgumentNullException(nameof(login));
+			Password = password ?? throw new ArgumentNullException(nameof(password));
+			SearchBase = searchBase ?? throw new ArgumentNullException(nameof(searchBase));
+			Filter = filter ?? throw new ArgumentNullException(nameof(filter));
+			ProtocolVersion = protocolVersion;
+			ResultPageSize = resultPageSize;
+			TargetAttributes = targetAttribute ?? throw new ArgumentNullException(nameof(targetAttribute));
+		}
+	}
+}


### PR DESCRIPTION
LDAP Control Extension for Simple Paged Results Manipulation (RFC 2629) support

Sometimes we need to retrieve large search result set (for example, 100 000 entries). This case we may face some troubles:

      - there are limits set on the LDAP server as when using Microsoft Active Directory and MaxPageSize is exceeded
      - low-bandwidth connection
      - the LDAP client has limited resources

The simple paged results control can be attached to a search operation to indicate that only a subset of the results should be returned. It may be used to iterate through the search results at a time. It is similar to virtual list view control but does not require the result set to be sorted and provides only the ability to iterate sequentially through the result set.