### PR TITLE
Make the MessageVector to be thread safe

### DIFF
--- a/src/Novell.Directory.Ldap.NETStandard/Connection.cs
+++ b/src/Novell.Directory.Ldap.NETStandard/Connection.cs
@@ -825,7 +825,7 @@ namespace Novell.Directory.Ldap
         /// </param>
         internal void RemoveMessage(Message info)
         {
-            SupportClass.VectorRemoveElement(_messages, info);
+            _messages.Remove(info);
         }
 
         private void Destroy(string reason, int semaphoreId, InterThreadException notifyUser)

--- a/src/Novell.Directory.Ldap.NETStandard/MessageAgent.cs
+++ b/src/Novell.Directory.Ldap.NETStandard/MessageAgent.cs
@@ -193,7 +193,7 @@ namespace Novell.Directory.Ldap
             {
                 // Send abandon request and remove from connection list
                 var info = _messages.FindMessageById(msgId);
-                SupportClass.VectorRemoveElement(_messages, info); // This message is now dead
+                _messages.Remove(info);
                 info.Abandon(cons, null);
             }
             catch (FieldAccessException ex)
@@ -212,7 +212,7 @@ namespace Novell.Directory.Ldap
                 var info = (Message)_messages[i];
 
                 // Message complete and no more replies, remove from id list
-                SupportClass.VectorRemoveElement(_messages, info);
+                _messages.Remove(info);
                 info.Abandon(null, null);
             }
         }
@@ -291,7 +291,7 @@ namespace Novell.Directory.Ldap
                     if (!info.AcceptsReplies() && !info.HasReplies())
                     {
                         // Message complete and no more replies, remove from id list
-                        SupportClass.VectorRemoveElement(_messages, info);
+                        _messages.Remove(info);
                         info.Abandon(null, null); // Get rid of resources
                     }
 
@@ -325,7 +325,7 @@ namespace Novell.Directory.Ldap
                         if (!info.AcceptsReplies() && !info.HasReplies())
                         {
                             // Message complete & no more replies, remove from id list
-                            SupportClass.VectorRemoveElement(_messages, info); // remove from list
+                            _messages.Remove(info); // remove from list
                             info.Abandon(null, null); // Get rid of resources
 
                             // Start loop at next message that is now moved

--- a/src/Novell.Directory.Ldap.NETStandard/MessageVector.cs
+++ b/src/Novell.Directory.Ldap.NETStandard/MessageVector.cs
@@ -40,11 +40,13 @@ namespace Novell.Directory.Ldap
     ///     The. <code>MessageVector</code> class implements additional semantics
     ///     to Vector needed for handling messages.
     /// </summary>
-    internal class MessageVector : ArrayList
+    internal class MessageVector
     {
+        private ArrayList _arrayList;
+
         internal MessageVector(int cap)
-            : base(cap)
         {
+            _arrayList = new ArrayList(cap);
         }
 
         /// <summary>
@@ -59,8 +61,8 @@ namespace Novell.Directory.Ldap
         {
             lock (this)
             {
-                var results = ToArray();
-                Clear();
+                var results = this.ToArray();
+                _arrayList.Clear();
                 return results;
             }
         }
@@ -81,13 +83,99 @@ namespace Novell.Directory.Ldap
         {
             lock (this)
             {
-                var message = this.OfType<Message>().SingleOrDefault(m => m.MessageId == msgId);
+                var message = _arrayList.OfType<Message>().SingleOrDefault(m => m.MessageId == msgId);
                 if (message == null)
                 {
                     throw new FieldAccessException();
                 }
 
                 return message;
+            }
+        }
+
+        /// <summary>
+        ///     Adds an object to the end of the Vector
+        /// </summary>
+        /// <returns>
+        ///     The  index at which the message has been added.
+        /// </returns>
+        public int Add(object message)
+        {
+            lock (this)
+            {
+                return _arrayList.Add(message);
+            }
+        }
+        
+        /// <summary>
+        ///     Removes the first occurrence of a specific object from the Vector.
+        /// </summary>
+        public void Remove(object message)
+        {
+            lock (this)
+            {
+                _arrayList.Remove(message);
+            }
+        }
+
+        /// <summary>
+        ///     Gets the number of elements actually contained in the Vector.
+        /// </summary>
+        public int Count
+        {
+            get
+            {
+                lock (this)
+                {
+                    return _arrayList.Count;
+                }
+            }
+        }
+
+        /// <summary>
+        ///     Gets the Message at the specified index.
+        /// </summary>
+        public object this[int index]
+        {
+            get
+            {
+                lock (this)
+                {
+                    return _arrayList[index];
+                }
+            }
+        }
+
+        /// <summary>
+        ///     Removes the element at the specified index.
+        /// </summary>
+        public void RemoveAt(int index)
+        {
+            lock (this)
+            {
+                _arrayList.RemoveAt(index);
+            }
+        }
+        
+        /// <summary>
+        ///     Copies the elements to a new array.
+        /// </summary>
+        public object[] ToArray()
+        {
+            lock (this)
+            {
+                return _arrayList.ToArray();
+            }
+        }  
+        
+        /// <summary>
+        ///     Removes all elements.
+        /// </summary>
+        public void Clear()
+        {
+            lock (this)
+            {
+                _arrayList.Clear();
             }
         }
     }


### PR DESCRIPTION
As it was reported already (https://github.com/dsbenghe/Novell.Directory.Ldap.NETStandard/issues/130) the `MessageVector` class 
had the race condition. This PR fixes it and also makes sure that there is locking around all remaining `MessageVector` methods. Note, that I've decided to use composition instead of inheritance for better control of which methods of the `ArrayList` type are used.


