### PR TITLE
Remove the unused method `SupportClass.VectorRemoveElement`

### DIFF
--- a/src/Novell.Directory.Ldap.NETStandard/SupportClass.cs
+++ b/src/Novell.Directory.Ldap.NETStandard/SupportClass.cs
@@ -101,21 +101,6 @@ namespace Novell.Directory.Ldap
             return literal;
         }
 
-        /*******************************/
-
-        /// <summary>
-        ///     Removes the first occurrence of an specific object from an ArrayList instance.
-        /// </summary>
-        /// <param name="arrayList">The ArrayList instance.</param>
-        /// <param name="element">The element to remove.</param>
-        /// <returns>True if item is found in the ArrayList; otherwise, false.</returns>
-        public static bool VectorRemoveElement(ArrayList arrayList, object element)
-        {
-            var containsItem = arrayList.Contains(element);
-            arrayList.Remove(element);
-            return containsItem;
-        }
-
         /// <summary>
         ///     Copies an array of chars obtained from a String into a specified array of chars.
         /// </summary>


### PR DESCRIPTION
`SupportClass.VectorRemoveElement` has public signature, but it is very unlikely anyone uses it in external code so I think it is ok to remove it.