### PR TITLE
Add .ConfigureAwait(false) to all await statements

### DIFF
--- a/src/Novell.Directory.Ldap.NETStandard/AsyncExtensions.cs
+++ b/src/Novell.Directory.Ldap.NETStandard/AsyncExtensions.cs
@@ -12,13 +12,13 @@ namespace Novell.Directory.Ldap
             {
                 if (timeout == 0)
                 {
-                    await task;
+                    await task.ConfigureAwait(false);
                 }
                 else
                 {
-                    if (task == await Task.WhenAny(task, Task.Delay(timeout)))
+                    if (task == await Task.WhenAny(task, Task.Delay(timeout)).ConfigureAwait(false))
                     {
-                        await task;
+                        await task.ConfigureAwait(false);
                     }
                     else
                     {

--- a/src/Novell.Directory.Ldap.NETStandard/Connection.cs
+++ b/src/Novell.Directory.Ldap.NETStandard/Connection.cs
@@ -534,7 +534,7 @@ namespace Novell.Directory.Ldap
 
                         if (!IPAddress.TryParse(host, out var ipAddress))
                         {
-                            var ipAddresses = await Dns.GetHostAddressesAsync(host);
+                            var ipAddresses = await Dns.GetHostAddressesAsync(host).ConfigureAwait(false);
                             ipAddress = ipAddresses
                                 .Where(x => _ldapConnectionOptions.IpAddressFilter(x))
                                 .FirstOrDefault(ip => ip.AddressFamily == AddressFamily.InterNetwork
@@ -550,7 +550,7 @@ namespace Novell.Directory.Ldap
                         {
                             _sock = new Socket(ipAddress.AddressFamily, SocketType.Stream, ProtocolType.IP);
                             var ipEndPoint = new IPEndPoint(ipAddress, port);
-                            await _sock.ConnectAsync(ipEndPoint).TimeoutAfterAsync(ConnectionTimeout);
+                            await _sock.ConnectAsync(ipEndPoint).TimeoutAfterAsync(ConnectionTimeout).ConfigureAwait(false);
 
                             var sslStream = new SslStream(
                                 new NetworkStream(_sock, true),
@@ -562,7 +562,8 @@ namespace Novell.Directory.Ldap
                                     new X509CertificateCollection(_ldapConnectionOptions.ClientCertificates.ToArray()),
                                     _ldapConnectionOptions.SslProtocols,
                                     _ldapConnectionOptions.CheckCertificateRevocationEnabled)
-                                .TimeoutAfterAsync(ConnectionTimeout);
+                                .TimeoutAfterAsync(ConnectionTimeout)
+                                .ConfigureAwait(false);
 
                             _inStream = sslStream;
                             _outStream = sslStream;
@@ -570,7 +571,7 @@ namespace Novell.Directory.Ldap
                         else
                         {
                             _socket = new TcpClient(ipAddress.AddressFamily);
-                            await _socket.ConnectAsync(host, port).TimeoutAfterAsync(ConnectionTimeout);
+                            await _socket.ConnectAsync(host, port).TimeoutAfterAsync(ConnectionTimeout).ConfigureAwait(false);
 
                             _inStream = _socket.GetStream();
                             _outStream = _socket.GetStream();
@@ -719,7 +720,7 @@ namespace Novell.Directory.Ldap
             // For bind requests, if not connected, attempt to reconnect
             if (info.BindRequest && Connected == false && Host != null)
             {
-                await ConnectAsync(Host, Port, info.MessageId);
+                await ConnectAsync(Host, Port, info.MessageId).ConfigureAwait(false);
             }
 
             if (Connected)
@@ -997,7 +998,8 @@ namespace Novell.Directory.Ldap
                         new X509CertificateCollection(_ldapConnectionOptions.ClientCertificates.ToArray()),
                         _ldapConnectionOptions.SslProtocols,
                         _ldapConnectionOptions.CheckCertificateRevocationEnabled)
-                    .TimeoutAfterAsync(ConnectionTimeout);
+                    .TimeoutAfterAsync(ConnectionTimeout)
+                    .ConfigureAwait(false);
 
                 _inStream = sslStream;
                 _outStream = sslStream;

--- a/src/Novell.Directory.Ldap.NETStandard/ILdapConnection.ExtensionMethods.cs
+++ b/src/Novell.Directory.Ldap.NETStandard/ILdapConnection.ExtensionMethods.cs
@@ -15,7 +15,9 @@ namespace Novell.Directory.Ldap
         /// </summary>
         public static async Task<RootDseInfo> GetRootDseInfoAsync(this ILdapConnection conn)
         {
-            var searchResults = await conn.SearchAsync(string.Empty, LdapConnection.ScopeBase, "(objectClass=*)", new string[] { "*", "+", "supportedExtension" }, false);
+            var searchResults = await conn
+                .SearchAsync(string.Empty, LdapConnection.ScopeBase, "(objectClass=*)", new string[] { "*", "+", "supportedExtension" }, false)
+                .ConfigureAwait(false);
             if (searchResults.HasMore())
             {
                 var sr = searchResults.Next();

--- a/src/Novell.Directory.Ldap.NETStandard/LdapConnection.Sasl.cs
+++ b/src/Novell.Directory.Ldap.NETStandard/LdapConnection.Sasl.cs
@@ -121,7 +121,7 @@ namespace Novell.Directory.Ldap
                     {
                         try
                         {
-                            var replyBuf = await SendLdapSaslBindRequestAsync(clientResponse, saslClient.MechanismName, bindProps, constraints);
+                            var replyBuf = await SendLdapSaslBindRequestAsync(clientResponse, saslClient.MechanismName, bindProps, constraints).ConfigureAwait(false);
 
                             if (replyBuf != null)
                             {
@@ -150,7 +150,7 @@ namespace Novell.Directory.Ldap
             constraints = constraints ?? _defSearchCons;
             var msg = new LdapSaslBindRequest(LdapV3, mechanism, constraints.GetControls(), toWrite);
 
-            var queue = await SendRequestToServerAsync(msg, constraints.TimeLimit, null, bindProps);
+            var queue = await SendRequestToServerAsync(msg, constraints.TimeLimit, null, bindProps).ConfigureAwait(false);
             if (!(queue.GetResponse() is LdapResponse ldapResponse))
             {
                 throw new LdapException("Bind failure, no response received.");

--- a/src/Novell.Directory.Ldap.NETStandard/LdapConnection.cs
+++ b/src/Novell.Directory.Ldap.NETStandard/LdapConnection.cs
@@ -493,12 +493,12 @@ namespace Novell.Directory.Ldap
                 Connection.StopReaderOnReply(tlsId);
 
                 // send tls message
-                var queue = await SendRequestToServerAsync(startTls, _defSearchCons.TimeLimit, null, null);
+                var queue = await SendRequestToServerAsync(startTls, _defSearchCons.TimeLimit, null, null).ConfigureAwait(false);
 
                 var response = (LdapExtendedResponse)queue.GetResponse();
                 response.ChkResultCode();
 
-                await Connection.StartTlsAsync();
+                await Connection.StartTlsAsync().ConfigureAwait(false);
             }
             finally
             {
@@ -548,7 +548,7 @@ namespace Novell.Directory.Ldap
         /// <inheritdoc />
         public async Task AddAsync(LdapEntry entry, LdapConstraints cons)
         {
-            var queue = await AddAsync(entry, null, cons);
+            var queue = await AddAsync(entry, null, cons).ConfigureAwait(false);
 
             // Get a handle to the add response
             var addResponse = (LdapResponse)queue.GetResponse();
@@ -559,7 +559,7 @@ namespace Novell.Directory.Ldap
                 _responseCtls = addResponse.Controls;
             }
 
-            await ChkResultCodeAsync(queue, cons, addResponse);
+            await ChkResultCodeAsync(queue, cons, addResponse).ConfigureAwait(false);
         }
 
         /// <inheritdoc />
@@ -601,7 +601,7 @@ namespace Novell.Directory.Ldap
         /// <inheritdoc />
         public async Task BindAsync(int version, string dn, byte[] passwd, LdapConstraints cons)
         {
-            var queue = await BindAsync(version, dn, passwd, null, cons);
+            var queue = await BindAsync(version, dn, passwd, null, cons).ConfigureAwait(false);
             var res = (LdapResponse)queue.GetResponse();
             if (res != null)
             {
@@ -611,7 +611,7 @@ namespace Novell.Directory.Ldap
                     _responseCtls = res.Controls;
                 }
 
-                await ChkResultCodeAsync(queue, cons, res);
+                await ChkResultCodeAsync(queue, cons, res).ConfigureAwait(false);
             }
         }
 
@@ -633,7 +633,7 @@ namespace Novell.Directory.Ldap
         /// <inheritdoc />
         public async Task DeleteAsync(string dn, LdapConstraints cons)
         {
-            var queue = await DeleteAsync(dn, null, cons);
+            var queue = await DeleteAsync(dn, null, cons).ConfigureAwait(false);
 
             // Get a handle to the delete response
             var deleteResponse = (LdapResponse)queue.GetResponse();
@@ -644,7 +644,7 @@ namespace Novell.Directory.Ldap
                 _responseCtls = deleteResponse.Controls;
             }
 
-            await ChkResultCodeAsync(queue, cons, deleteResponse);
+            await ChkResultCodeAsync(queue, cons, deleteResponse).ConfigureAwait(false);
         }
 
         /// <inheritdoc />
@@ -664,7 +664,7 @@ namespace Novell.Directory.Ldap
         public async Task<LdapExtendedResponse> ExtendedOperationAsync(LdapExtendedOperation op, LdapConstraints cons)
         {
             // Call asynchronous API and get back handler to response queue
-            var queue = await ExtendedOperationAsync(op, cons, null);
+            var queue = await ExtendedOperationAsync(op, cons, null).ConfigureAwait(false);
             var queueResponse = queue.GetResponse();
             var response = (LdapExtendedResponse)queueResponse;
 
@@ -674,7 +674,7 @@ namespace Novell.Directory.Ldap
                 _responseCtls = response.Controls;
             }
 
-            await ChkResultCodeAsync(queue, cons, response);
+            await ChkResultCodeAsync(queue, cons, response).ConfigureAwait(false);
             return response;
         }
 
@@ -701,7 +701,7 @@ namespace Novell.Directory.Ldap
         /// <inheritdoc />
         public async Task ModifyAsync(string dn, LdapModification[] mods, LdapConstraints cons)
         {
-            var queue = await ModifyAsync(dn, mods, null, cons);
+            var queue = await ModifyAsync(dn, mods, null, cons).ConfigureAwait(false);
 
             // Get a handle to the modify response
             var modifyResponse = (LdapResponse)queue.GetResponse();
@@ -712,7 +712,7 @@ namespace Novell.Directory.Ldap
                 _responseCtls = modifyResponse.Controls;
             }
 
-            await ChkResultCodeAsync(queue, cons, modifyResponse);
+            await ChkResultCodeAsync(queue, cons, modifyResponse).ConfigureAwait(false);
         }
 
         /// <inheritdoc />
@@ -736,7 +736,7 @@ namespace Novell.Directory.Ldap
         /// <inheritdoc />
         public async Task<LdapEntry> ReadAsync(string dn, string[] attrs, LdapSearchConstraints cons)
         {
-            var sr = await SearchAsync(dn, ScopeBase, null, attrs, false, cons);
+            var sr = await SearchAsync(dn, ScopeBase, null, attrs, false, cons).ConfigureAwait(false);
 
             if (!sr.HasMore())
             {
@@ -775,7 +775,7 @@ namespace Novell.Directory.Ldap
         /// <inheritdoc />
         public async Task RenameAsync(string dn, string newRdn, string newParentdn, bool deleteOldRdn, LdapConstraints cons)
         {
-            var queue = await RenameAsync(dn, newRdn, newParentdn, deleteOldRdn, null, cons);
+            var queue = await RenameAsync(dn, newRdn, newParentdn, deleteOldRdn, null, cons).ConfigureAwait(false);
 
             // Get a handle to the rename response
             var renameResponse = (LdapResponse)queue.GetResponse();
@@ -786,7 +786,7 @@ namespace Novell.Directory.Ldap
                 _responseCtls = renameResponse.Controls;
             }
 
-            await ChkResultCodeAsync(queue, cons, renameResponse);
+            await ChkResultCodeAsync(queue, cons, renameResponse).ConfigureAwait(false);
         }
 
         /// <inheritdoc />
@@ -799,7 +799,7 @@ namespace Novell.Directory.Ldap
         public async Task<ILdapSearchResults> SearchAsync(string @base, int scope, string filter, string[] attrs, bool typesOnly,
             LdapSearchConstraints cons)
         {
-            var queue = await SearchAsync(@base, scope, filter, attrs, typesOnly, null, cons);
+            var queue = await SearchAsync(@base, scope, filter, attrs, typesOnly, null, cons).ConfigureAwait(false);
 
             if (cons == null)
             {
@@ -1319,7 +1319,7 @@ namespace Novell.Directory.Ldap
             {
                 if (Connection.Host != null)
                 {
-                    await Connection.ConnectAsync(Connection.Host, Connection.Port);
+                    await Connection.ConnectAsync(Connection.Host, Connection.Port).ConfigureAwait(false);
                 }
                 else
                 {
@@ -1330,7 +1330,7 @@ namespace Novell.Directory.Ldap
             // The semaphore is released when the bind response is queued.
             Connection.AcquireWriteSemaphore(msgId);
 
-            return await SendRequestToServerAsync(msg, cons.TimeLimit, queue, bindProps);
+            return await SendRequestToServerAsync(msg, cons.TimeLimit, queue, bindProps).ConfigureAwait(false);
         }
 
         // *************************************************************************
@@ -1395,7 +1395,7 @@ namespace Novell.Directory.Ldap
         {
             var ret = false;
 
-            var queue = await CompareAsync(dn, attr, null, cons);
+            var queue = await CompareAsync(dn, attr, null, cons).ConfigureAwait(false);
 
             var res = (LdapResponse)queue.GetResponse();
 
@@ -1415,7 +1415,7 @@ namespace Novell.Directory.Ldap
             }
             else
             {
-                await ChkResultCodeAsync(queue, cons, res);
+                await ChkResultCodeAsync(queue, cons, res).ConfigureAwait(false);
             }
 
             return ret;
@@ -1882,8 +1882,8 @@ namespace Novell.Directory.Ldap
         {
             using (var lconn = new LdapConnection())
             {
-                await lconn.ConnectAsync(toGet.Host, toGet.Port);
-                return await lconn.ReadAsync(toGet.GetDn(), toGet.AttributeArray, cons);
+                await lconn.ConnectAsync(toGet.Host, toGet.Port).ConfigureAwait(false);
+                return await lconn.ReadAsync(toGet.GetDn(), toGet.AttributeArray, cons).ConfigureAwait(false);
             }
         }
 
@@ -2152,7 +2152,7 @@ namespace Novell.Directory.Ldap
                 agent = queue.MessageAgent;
             }
 
-            await agent.SendMessageAsync(Connection, msg, cons.TimeLimit, null);
+            await agent.SendMessageAsync(Connection, msg, cons.TimeLimit, null).ConfigureAwait(false);
             return myqueue;
         }
 
@@ -2209,7 +2209,7 @@ namespace Novell.Directory.Ldap
         {
             using (var lconn = new LdapConnection())
             {
-                await lconn.ConnectAsync(toGet.Host, toGet.Port);
+                await lconn.ConnectAsync(toGet.Host, toGet.Port).ConfigureAwait(false);
                 if (cons == null)
                 {
                     // This is a clone, so we already have our own copy
@@ -2223,7 +2223,7 @@ namespace Novell.Directory.Ldap
 
                 cons.BatchSize = 0; // Must wait until all results arrive
                 return await lconn.SearchAsync(toGet.GetDn(), toGet.Scope, toGet.Filter, toGet.AttributeArray, false,
-                    cons);
+                    cons).ConfigureAwait(false);
             }
         }
 
@@ -2321,7 +2321,7 @@ namespace Novell.Directory.Ldap
                 agent = queue.MessageAgent;
             }
 
-            await agent.SendMessageAsync(Connection, request, cons.TimeLimit, null);
+            await agent.SendMessageAsync(Connection, request, cons.TimeLimit, null).ConfigureAwait(false);
 
             return myqueue;
         }
@@ -2364,7 +2364,7 @@ namespace Novell.Directory.Ldap
                 agent = queue.MessageAgent;
             }
 
-            await agent.SendMessageAsync(Connection, msg, timeout, bindProps);
+            await agent.SendMessageAsync(Connection, msg, timeout, bindProps).ConfigureAwait(false);
             return queue;
         }
 
@@ -2406,7 +2406,7 @@ namespace Novell.Directory.Ldap
                             Constraints = _defSearchCons,
                         };
                         var url = new LdapUrl(referrals[i]);
-                        await rconn.ConnectAsync(url.Host, url.Port);
+                        await rconn.ConnectAsync(url.Host, url.Port).ConfigureAwait(false);
                         if (rh is ILdapAuthHandler)
                         {
                             // Get application supplied dn and pw
@@ -2415,7 +2415,7 @@ namespace Novell.Directory.Ldap
                             pw = ap.Password;
                         }
 
-                        await rconn.BindAsync(LdapV3, dn, pw);
+                        await rconn.BindAsync(LdapV3, dn, pw).ConfigureAwait(false);
                         ex = null;
                         refInfo = new ReferralInfo(rconn, referrals, url);
 
@@ -2546,7 +2546,7 @@ namespace Novell.Directory.Ldap
                 List<object> refConn = null;
                 try
                 {
-                    await ChaseReferralAsync(queue, cons, response, response.Referrals, 0, false, null);
+                    await ChaseReferralAsync(queue, cons, response, response.Referrals, 0, false, null).ConfigureAwait(false);
                 }
                 finally
                 {
@@ -2650,7 +2650,7 @@ namespace Novell.Directory.Ldap
                 }
 
                 // Get a connection to follow the referral
-                rinfo = await GetReferralConnectionAsync(refs);
+                rinfo = await GetReferralConnectionAsync(refs).ConfigureAwait(false);
                 var rconn = rinfo.ReferralConnection; // new conn for following referral
                 refUrl = rinfo.ReferralUrl;
                 connList.Add(rconn);
@@ -2671,7 +2671,7 @@ namespace Novell.Directory.Ldap
                         agent = queue.MessageAgent;
                     }
 
-                    await agent.SendMessageAsync(rconn.Connection, newMsg, _defSearchCons.TimeLimit, null);
+                    await agent.SendMessageAsync(rconn.Connection, newMsg, _defSearchCons.TimeLimit, null).ConfigureAwait(false);
                 }
                 catch (InterThreadException ex)
                 {
@@ -2690,7 +2690,7 @@ namespace Novell.Directory.Ldap
                     // the stack unwinds back to the original and returns
                     // to the application.
                     // An exception is thrown for an error
-                    connList = await ChaseReferralAsync(queue, cons, null, null, hopCount, false, connList);
+                    connList = await ChaseReferralAsync(queue, cons, null, null, hopCount, false, connList).ConfigureAwait(false);
                 }
                 else
                 {
@@ -2832,7 +2832,7 @@ namespace Novell.Directory.Ldap
         /// </seealso>
         public async Task<LdapSchema> FetchSchemaAsync(string schemaDn)
         {
-            var ent = await ReadAsync(schemaDn, LdapSchema.SchemaTypeNames);
+            var ent = await ReadAsync(schemaDn, LdapSchema.SchemaTypeNames).ConfigureAwait(false);
             return new LdapSchema(ent);
         }
 
@@ -2893,7 +2893,7 @@ namespace Novell.Directory.Ldap
 
             /* Read the entries subschemaSubentry attribute. Throws an exception if
             * no entries are returned. */
-            var ent = await ReadAsync(dn, attrSubSchema);
+            var ent = await ReadAsync(dn, attrSubSchema).ConfigureAwait(false);
 
             var attr = ent.GetAttribute(attrSubSchema[0]);
             var values = attr.StringValueArray;

--- a/src/Novell.Directory.Ldap.NETStandard/LdapSearchResults.cs
+++ b/src/Novell.Directory.Ldap.NETStandard/LdapSearchResults.cs
@@ -132,7 +132,7 @@ namespace Novell.Directory.Ldap
 
                             if (_cons.ReferralFollowing)
                             {
-                                _referralConn = await _conn.ChaseReferralAsync(_queue, _cons, msg, refs, 0, true, _referralConn);
+                                _referralConn = await _conn.ChaseReferralAsync(_queue, _cons, msg, refs, 0, true, _referralConn).ConfigureAwait(false);
                             }
                             else
                             {
@@ -156,7 +156,7 @@ namespace Novell.Directory.Ldap
                             if (resultCode == LdapException.Referral && _cons.ReferralFollowing)
                             {
                                 // Following referrals
-                                _referralConn = await _conn.ChaseReferralAsync(_queue, _cons, resp, resp.Referrals, 0, false, _referralConn);
+                                _referralConn = await _conn.ChaseReferralAsync(_queue, _cons, resp, resp.Referrals, 0, false, _referralConn).ConfigureAwait(false);
                             }
                             else if (resultCode != LdapException.Success)
                             {
@@ -364,7 +364,7 @@ namespace Novell.Directory.Ldap
             // If no data at all, must reload enumeration
             if (_referenceIndex == 0 && _referenceCount == 0 && _entryIndex == 0 && _entryCount == 0)
             {
-                _completed = await GetBatchOfResultsAsync();
+                _completed = await GetBatchOfResultsAsync().ConfigureAwait(false);
             }
         }
 
@@ -376,7 +376,7 @@ namespace Novell.Directory.Ldap
             _queue.MessageAgent.AbandonAll();
 
             // next, clear out enumeration
-            await ResetVectorsAsync();
+            await ResetVectorsAsync().ConfigureAwait(false);
             _completed = true;
         }
 

--- a/src/Novell.Directory.Ldap.NETStandard/Message.cs
+++ b/src/Novell.Directory.Ldap.NETStandard/Message.cs
@@ -231,7 +231,7 @@ namespace Novell.Directory.Ldap
 
         internal async Task SendMessageAsync()
         {
-            await _conn.WriteMessageAsync(this);
+            await _conn.WriteMessageAsync(this).ConfigureAwait(false);
 
             // Start the timer thread
             if (_mslimit != 0)

--- a/src/Novell.Directory.Ldap.NETStandard/SearchExtensions/SimplePagedResultsControlHandler.cs
+++ b/src/Novell.Directory.Ldap.NETStandard/SearchExtensions/SimplePagedResultsControlHandler.cs
@@ -53,7 +53,7 @@ namespace Novell.Directory.Ldap
             var isNextPageAvailable = PrepareForNextPage(null, pageSize, true, ref searchConstraints);
             while (isNextPageAvailable)
             {
-                var responseControls = await RetrievePageAsync(options, searchConstraints, searchResult, converter);
+                var responseControls = await RetrievePageAsync(options, searchConstraints, searchResult, converter).ConfigureAwait(false);
                 isNextPageAvailable = PrepareForNextPage(responseControls, pageSize, false, ref searchConstraints);
             }
 
@@ -119,7 +119,7 @@ namespace Novell.Directory.Ldap
                     options.TargetAttributes,
                     false,
                     searchConstraints
-                );
+                ).ConfigureAwait(false);
 
             mappedResultsAccumulator.AddRange(searchResults.Select(converter));
 

--- a/src/Novell.Directory.Ldap.NETStandard/SearchExtensions/VirtualListViewControlHandler.cs
+++ b/src/Novell.Directory.Ldap.NETStandard/SearchExtensions/VirtualListViewControlHandler.cs
@@ -87,7 +87,7 @@ namespace Novell.Directory.Ldap.SearchExtensions
                     options.Filter,
                     options.TargetAttributes,
                     options.TypesOnly,
-                    searchConstraints)).ToList();
+                    searchConstraints).ConfigureAwait(false)).ToList();
 
                 entries.AddRange(searchResults.Select(converter));
 


### PR DESCRIPTION
A library should always use `.ConfigureAwait(false)`

Here is a nice FAQ for this topic: https://devblogs.microsoft.com/dotnet/configureawait-faq/#when-should-i-use-configureawaitfalse

> This leads to the general guidance of: if you’re writing general-purpose library code, use ConfigureAwait(false). This is why, for example, you’ll see every (or almost every) await in the .NET Core runtime libraries using ConfigureAwait(false) on every await; with a few exceptions, in cases where it doesn’t it’s very likely a bug to be fixed. 

