### PR TITLE
Move ILdapSearchResults to async (implement IAsyncEnumerable instead of IEnumerable)

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 [![Build Status](https://dev.azure.com/dsbenghe/Ldap/_apis/build/status/Novell.Directory.Ldap.NETStandard?branchName=develop)](https://dev.azure.com/dsbenghe/Ldap/_build/latest?definitionId=6&branchName=develop) [![NuGet](https://img.shields.io/nuget/vpre/Novell.Directory.Ldap.NETStandard.svg)](https://www.nuget.org/packages/Novell.Directory.Ldap.NETStandard/absoluteLatest) - Developing version - Win2019/Linux/MacOS CI
 
-LDAP client library - .NET Standard 1.3/2.0/2.1 and .NET5 - compatible .NET platforms: .NET5, .NET Core >= 1.0, .NET Framework >= 4.6, Universal Windows Platform, Xamarin (see here for a more detailed description of supported platforms https://docs.microsoft.com/en-us/dotnet/articles/standard/library ).
+LDAP client library - .NET Standard 2.0/2.1 and .NET5 - compatible .NET platforms: .NET5, .NET Core >= 2.0, .NET Framework >= 4.6.1, Universal Windows Platform, Xamarin (see here for a more detailed description of supported platforms https://docs.microsoft.com/en-us/dotnet/articles/standard/library ).
 
 It works with any LDAP protocol compatible directory server (including Microsoft Active Directory).
 

--- a/src/Novell.Directory.Ldap.NETStandard/ILdapConnection.ExtensionMethods.cs
+++ b/src/Novell.Directory.Ldap.NETStandard/ILdapConnection.ExtensionMethods.cs
@@ -18,9 +18,10 @@ namespace Novell.Directory.Ldap
             var searchResults = await conn
                 .SearchAsync(string.Empty, LdapConnection.ScopeBase, "(objectClass=*)", new string[] { "*", "+", "supportedExtension" }, false)
                 .ConfigureAwait(false);
-            if (searchResults.HasMore())
+
+            if (await searchResults.HasMoreAsync().ConfigureAwait(false))
             {
-                var sr = searchResults.Next();
+                var sr = await searchResults.NextAsync().ConfigureAwait(false);
                 return new RootDseInfo(sr);
             }
 

--- a/src/Novell.Directory.Ldap.NETStandard/ILdapConnection.ExtensionMethods.cs
+++ b/src/Novell.Directory.Ldap.NETStandard/ILdapConnection.ExtensionMethods.cs
@@ -19,10 +19,13 @@ namespace Novell.Directory.Ldap
                 .SearchAsync(string.Empty, LdapConnection.ScopeBase, "(objectClass=*)", new string[] { "*", "+", "supportedExtension" }, false)
                 .ConfigureAwait(false);
 
-            if (await searchResults.HasMoreAsync().ConfigureAwait(false))
+            var enumerator = searchResults.GetAsyncEnumerator();
+            await using (enumerator.ConfigureAwait(false))
             {
-                var sr = await searchResults.NextAsync().ConfigureAwait(false);
-                return new RootDseInfo(sr);
+                if (await enumerator.MoveNextAsync().ConfigureAwait(false))
+                {
+                    return new RootDseInfo(enumerator.Current);
+                }
             }
 
             return null;

--- a/src/Novell.Directory.Ldap.NETStandard/ILdapSearchResults.cs
+++ b/src/Novell.Directory.Ldap.NETStandard/ILdapSearchResults.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using System.Threading.Tasks;
 
 namespace Novell.Directory.Ldap
 {
@@ -10,7 +11,7 @@ namespace Novell.Directory.Ldap
     /// </summary>
     /// <seealso cref="!:LdapConnection.Search">
     /// </seealso>
-    public interface ILdapSearchResults : IEnumerable<LdapEntry>
+    public interface ILdapSearchResults : IAsyncEnumerable<LdapEntry>
     {
         /// <summary>
         ///     Returns a count of the items in the search result.
@@ -32,7 +33,7 @@ namespace Novell.Directory.Ldap
         /// <returns>
         ///     true if there are more search results.
         /// </returns>
-        bool HasMore();
+        Task<bool> HasMoreAsync();
 
         /// <summary>
         ///     Returns the next result as an LdapEntry.
@@ -51,7 +52,7 @@ namespace Novell.Directory.Ldap
         ///     LdapReferralException A referral was received and not
         ///     followed.
         /// </exception>
-        LdapEntry Next();
+        Task<LdapEntry> NextAsync();
 
         /// <summary>
         ///     Returns the latest server controls returned by the server

--- a/src/Novell.Directory.Ldap.NETStandard/ILdapSearchResults.cs
+++ b/src/Novell.Directory.Ldap.NETStandard/ILdapSearchResults.cs
@@ -14,47 +14,6 @@ namespace Novell.Directory.Ldap
     public interface ILdapSearchResults : IAsyncEnumerable<LdapEntry>
     {
         /// <summary>
-        ///     Returns a count of the items in the search result.
-        ///     Returns a count of the entries and exceptions remaining in the object.
-        ///     If the search was submitted with a batch size greater than zero,
-        ///     getCount reports the number of results received so far but not enumerated
-        ///     with next().  If batch size equals zero, getCount reports the number of
-        ///     items received, since the application thread blocks until all results are
-        ///     received.
-        /// </summary>
-        /// <returns>
-        ///     The number of items received but not retrieved by the application.
-        /// </returns>
-        int Count { get; }
-
-        /// <summary>
-        ///     Reports if there are more search results.
-        /// </summary>
-        /// <returns>
-        ///     true if there are more search results.
-        /// </returns>
-        Task<bool> HasMoreAsync();
-
-        /// <summary>
-        ///     Returns the next result as an LdapEntry.
-        ///     If automatic referral following is disabled or if a referral
-        ///     was not followed, next() will throw an LdapReferralException
-        ///     when the referral is received.
-        /// </summary>
-        /// <returns>
-        ///     The next search result as an LdapEntry.
-        /// </returns>
-        /// <exception>
-        ///     LdapException A general exception which includes an error
-        ///     message and an Ldap error code.
-        /// </exception>
-        /// <exception>
-        ///     LdapReferralException A referral was received and not
-        ///     followed.
-        /// </exception>
-        Task<LdapEntry> NextAsync();
-
-        /// <summary>
         ///     Returns the latest server controls returned by the server
         ///     in the context of this search request, or null
         ///     if no server controls were returned.

--- a/src/Novell.Directory.Ldap.NETStandard/LdapConnection.cs
+++ b/src/Novell.Directory.Ldap.NETStandard/LdapConnection.cs
@@ -738,13 +738,13 @@ namespace Novell.Directory.Ldap
         {
             var sr = await SearchAsync(dn, ScopeBase, null, attrs, false, cons).ConfigureAwait(false);
 
-            if (!sr.HasMore())
+            if (!await sr.HasMoreAsync().ConfigureAwait(false))
             {
                 return null;
             }
 
-            var ret = sr.Next();
-            if (sr.HasMore())
+            var ret = await sr.NextAsync().ConfigureAwait(false);
+            if (await sr.HasMoreAsync().ConfigureAwait(false))
             {
                 // "Read response is ambiguous, multiple entries returned"
                 throw new LdapLocalException(ExceptionMessages.ReadMultiple, LdapException.AmbiguousResponse);

--- a/src/Novell.Directory.Ldap.NETStandard/LdapConnection.cs
+++ b/src/Novell.Directory.Ldap.NETStandard/LdapConnection.cs
@@ -736,21 +736,25 @@ namespace Novell.Directory.Ldap
         /// <inheritdoc />
         public async Task<LdapEntry> ReadAsync(string dn, string[] attrs, LdapSearchConstraints cons)
         {
-            var sr = await SearchAsync(dn, ScopeBase, null, attrs, false, cons).ConfigureAwait(false);
+            var searchResults = await SearchAsync(dn, ScopeBase, null, attrs, false, cons).ConfigureAwait(false);
 
-            if (!await sr.HasMoreAsync().ConfigureAwait(false))
+            var enumerator = searchResults.GetAsyncEnumerator();
+            await using (enumerator.ConfigureAwait(false))
             {
-                return null;
-            }
+                if (!await enumerator.MoveNextAsync().ConfigureAwait(false))
+                {
+                    return null;
+                }
 
-            var ret = await sr.NextAsync().ConfigureAwait(false);
-            if (await sr.HasMoreAsync().ConfigureAwait(false))
-            {
-                // "Read response is ambiguous, multiple entries returned"
-                throw new LdapLocalException(ExceptionMessages.ReadMultiple, LdapException.AmbiguousResponse);
-            }
+                var ret = enumerator.Current;
+                if (await enumerator.MoveNextAsync().ConfigureAwait(false))
+                {
+                    // "Read response is ambiguous, multiple entries returned"
+                    throw new LdapLocalException(ExceptionMessages.ReadMultiple, LdapException.AmbiguousResponse);
+                }
 
-            return ret;
+                return ret;
+            }
         }
 
         /// <inheritdoc />

--- a/src/Novell.Directory.Ldap.NETStandard/LdapExtensions/ExtensionRegistrations.cs
+++ b/src/Novell.Directory.Ldap.NETStandard/LdapExtensions/ExtensionRegistrations.cs
@@ -11,7 +11,7 @@ namespace Novell.Directory.Ldap
 
         public static async Task<LdapWhoAmIResponse> WhoAmIAsync(this LdapConnection conn, LdapConstraints cons = null)
         {
-            var result = await conn.ExtendedOperationAsync(new LdapWhoAmIOperation(), cons);
+            var result = await conn.ExtendedOperationAsync(new LdapWhoAmIOperation(), cons).ConfigureAwait(false);
             if (result is LdapWhoAmIResponse whoami)
             {
                 return whoami;

--- a/src/Novell.Directory.Ldap.NETStandard/LdapSearchResults.cs
+++ b/src/Novell.Directory.Ldap.NETStandard/LdapSearchResults.cs
@@ -224,7 +224,7 @@ namespace Novell.Directory.Ldap
         /// <returns>
         ///     true if there are more search results.
         /// </returns>
-        public async Task<bool> HasMoreAsync()
+        private async Task<bool> HasMoreAsync()
         {
             var ret = false;
             if (_entryIndex < _entryCount || _referenceIndex < _referenceCount)
@@ -259,7 +259,7 @@ namespace Novell.Directory.Ldap
         ///     LdapReferralException A referral was received and not
         ///     followed.
         /// </exception>
-        public async Task<LdapEntry> NextAsync()
+        private async Task<LdapEntry> NextAsync()
         {
             if (_completed && _entryIndex >= _entryCount && _referenceIndex >= _referenceCount)
             {

--- a/src/Novell.Directory.Ldap.NETStandard/Novell.Directory.Ldap.NETStandard.csproj
+++ b/src/Novell.Directory.Ldap.NETStandard/Novell.Directory.Ldap.NETStandard.csproj
@@ -6,7 +6,7 @@
     <Summary>.NET Standard LDAP client library</Summary>
     <VersionPrefix>4.0.0-beta2</VersionPrefix>
     <Authors>Novell;dsbenghe</Authors>
-    <TargetFrameworks>netstandard1.3;netstandard2.0;netstandard2.1;net5</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;netstandard2.1;net5</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <AssemblyName>Novell.Directory.Ldap.NETStandard</AssemblyName>
     <PackageId>Novell.Directory.Ldap.NETStandard</PackageId>
@@ -22,6 +22,7 @@
     <GenerateAssemblyVersionAttribute>false</GenerateAssemblyVersionAttribute>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <RootNamespace>Novell.Directory.Ldap</RootNamespace>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <PropertyGroup>
     <!-- CS1570 XML comment has badly formed XML -->
@@ -38,24 +39,9 @@
     <AssemblyOriginatorKeyFile>sign.snk</AssemblyOriginatorKeyFile>
   </PropertyGroup>
 
-  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard1.3'">
-    <Compile Update="ExtensionMethods.*.cs">
-      <DependentUpon>ExtensionMethods.cs</DependentUpon>
-    </Compile>
-  </ItemGroup>
-
-  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard1.3'">
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="1.1.2" />
-    <PackageReference Include="System.Collections.NonGeneric" Version="4.3.0" />
-    <PackageReference Include="System.Net.NameResolution" Version="4.3.0" />
-    <PackageReference Include="System.Net.Requests" Version="4.3.0" />
-    <PackageReference Include="System.Net.Security" Version="4.3.2" />
-    <PackageReference Include="System.Reflection.TypeExtensions" Version="4.5.0" />
-    <PackageReference Include="System.Threading.Thread" Version="4.3.0" />
-  </ItemGroup>
-
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="2.2.0" />
+    <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="5.0.0" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.1'">
@@ -65,8 +51,9 @@
   <ItemGroup Condition="'$(TargetFramework)' == 'net5'">
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="5.0.0" />
   </ItemGroup>
-  
+
   <ItemGroup>
+    <PackageReference Include="System.Linq.Async" Version="5.0.0" />
     <PackageReference Include="AsyncFixer" Version="1.1.6">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/src/Novell.Directory.Ldap.NETStandard/SearchExtensions/SimplePagedResultsControlHandler.cs
+++ b/src/Novell.Directory.Ldap.NETStandard/SearchExtensions/SimplePagedResultsControlHandler.cs
@@ -112,7 +112,7 @@ namespace Novell.Directory.Ldap
                 throw new ArgumentNullException(nameof(mappedResultsAccumulator));
             }
 
-            var searchResults = await _ldapConnection.SearchAsync(
+            var asyncSearchResults = await _ldapConnection.SearchAsync(
                     options.SearchBase,
                     LdapConnection.ScopeSub,
                     options.Filter,
@@ -121,9 +121,11 @@ namespace Novell.Directory.Ldap
                     searchConstraints
                 ).ConfigureAwait(false);
 
+            var searchResults = await asyncSearchResults.ToListAsync().ConfigureAwait(false);
+
             mappedResultsAccumulator.AddRange(searchResults.Select(converter));
 
-            return searchResults.ResponseControls;
+            return asyncSearchResults.ResponseControls;
         }
     }
 }

--- a/src/Novell.Directory.Ldap.NETStandard/SearchExtensions/SimplePagedResultsControlHandler.cs
+++ b/src/Novell.Directory.Ldap.NETStandard/SearchExtensions/SimplePagedResultsControlHandler.cs
@@ -3,6 +3,7 @@ using Novell.Directory.Ldap.Controls;
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace Novell.Directory.Ldap
@@ -21,7 +22,10 @@ namespace Novell.Directory.Ldap
             _ldapConnection = ldapConnection ?? throw new ArgumentNullException(nameof(ldapConnection));
         }
 
-        public Task<List<LdapEntry>> SearchWithSimplePagingAsync([NotNull] SearchOptions options, int pageSize)
+        public Task<List<LdapEntry>> SearchWithSimplePagingAsync(
+            [NotNull] SearchOptions options,
+            int pageSize,
+            CancellationToken cancellationToken = default)
         {
             if (options == null)
             {
@@ -33,10 +37,14 @@ namespace Novell.Directory.Ldap
                 throw new ArgumentOutOfRangeException(nameof(pageSize));
             }
 
-            return SearchWithSimplePagingAsync(entry => entry, options, pageSize);
+            return SearchWithSimplePagingAsync(entry => entry, options, pageSize, cancellationToken);
         }
 
-        public async Task<List<T>> SearchWithSimplePagingAsync<T>([NotNull] Func<LdapEntry, T> converter, [NotNull] SearchOptions options, int pageSize)
+        public async Task<List<T>> SearchWithSimplePagingAsync<T>(
+            [NotNull] Func<LdapEntry, T> converter,
+            [NotNull] SearchOptions options,
+            int pageSize,
+            CancellationToken cancellationToken = default)
         {
             if (converter == null)
             {
@@ -53,7 +61,7 @@ namespace Novell.Directory.Ldap
             var isNextPageAvailable = PrepareForNextPage(null, pageSize, true, ref searchConstraints);
             while (isNextPageAvailable)
             {
-                var responseControls = await RetrievePageAsync(options, searchConstraints, searchResult, converter).ConfigureAwait(false);
+                var responseControls = await RetrievePageAsync(options, searchConstraints, searchResult, converter, cancellationToken).ConfigureAwait(false);
                 isNextPageAvailable = PrepareForNextPage(responseControls, pageSize, false, ref searchConstraints);
             }
 
@@ -100,7 +108,8 @@ namespace Novell.Directory.Ldap
             [NotNull] SearchOptions options,
             [NotNull] LdapSearchConstraints searchConstraints,
             [NotNull] List<T> mappedResultsAccumulator,
-            [NotNull] Func<LdapEntry, T> converter)
+            [NotNull] Func<LdapEntry, T> converter,
+            CancellationToken cancellationToken = default)
         {
             if (searchConstraints == null)
             {
@@ -121,7 +130,7 @@ namespace Novell.Directory.Ldap
                     searchConstraints
                 ).ConfigureAwait(false);
 
-            var searchResults = await asyncSearchResults.ToListAsync().ConfigureAwait(false);
+            var searchResults = await asyncSearchResults.ToListAsync(cancellationToken).ConfigureAwait(false);
 
             mappedResultsAccumulator.AddRange(searchResults.Select(converter));
 

--- a/src/Novell.Directory.Ldap.NETStandard/SearchExtensions/SimplePagedResultsControlSearchExtensions.cs
+++ b/src/Novell.Directory.Ldap.NETStandard/SearchExtensions/SimplePagedResultsControlSearchExtensions.cs
@@ -2,6 +2,7 @@
 using Novell.Directory.Ldap.Controls;
 using System;
 using System.Collections.Generic;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace Novell.Directory.Ldap
@@ -12,7 +13,11 @@ namespace Novell.Directory.Ldap
     /// </summary>
     public static class SimplePagedResultsControlSearchExtensions
     {
-        public static Task<List<LdapEntry>> SearchUsingSimplePagingAsync([NotNull] this ILdapConnection ldapConnection, [NotNull] SearchOptions options, int pageSize)
+        public static Task<List<LdapEntry>> SearchUsingSimplePagingAsync(
+            [NotNull] this ILdapConnection ldapConnection,
+            [NotNull] SearchOptions options,
+            int pageSize,
+            CancellationToken cancellationToken = default)
         {
             if (ldapConnection == null)
             {
@@ -30,10 +35,15 @@ namespace Novell.Directory.Ldap
             }
 
             return new SimplePagedResultsControlHandler(ldapConnection)
-                .SearchWithSimplePagingAsync(options, pageSize);
+                .SearchWithSimplePagingAsync(options, pageSize, cancellationToken);
         }
 
-        public static Task<List<T>> SearchUsingSimplePagingAsync<T>([NotNull] this ILdapConnection ldapConnection, [NotNull] Func<LdapEntry, T> converter, [NotNull] SearchOptions options, int pageSize)
+        public static Task<List<T>> SearchUsingSimplePagingAsync<T>(
+            [NotNull] this ILdapConnection ldapConnection,
+            [NotNull] Func<LdapEntry, T> converter,
+            [NotNull] SearchOptions options,
+            int pageSize,
+            CancellationToken cancellationToken = default)
         {
             if (ldapConnection == null)
             {
@@ -51,7 +61,7 @@ namespace Novell.Directory.Ldap
             }
 
             return new SimplePagedResultsControlHandler(ldapConnection)
-                .SearchWithSimplePagingAsync(converter, options, pageSize);
+                .SearchWithSimplePagingAsync(converter, options, pageSize, cancellationToken);
         }
     }
 }

--- a/src/Novell.Directory.Ldap.NETStandard/SearchExtensions/VirtualListViewControlHandler.cs
+++ b/src/Novell.Directory.Ldap.NETStandard/SearchExtensions/VirtualListViewControlHandler.cs
@@ -81,13 +81,15 @@ namespace Novell.Directory.Ldap.SearchExtensions
                     sortControl,
                 });
 
-                var searchResults = (await _ldapConnection.SearchAsync(
+                var asyncSearchResults = await _ldapConnection.SearchAsync(
                     options.SearchBase,
                     LdapConnection.ScopeSub,
                     options.Filter,
                     options.TargetAttributes,
                     options.TypesOnly,
-                    searchConstraints).ConfigureAwait(false)).ToList();
+                    searchConstraints).ConfigureAwait(false);
+
+                var searchResults = await asyncSearchResults.ToListAsync().ConfigureAwait(false);
 
                 entries.AddRange(searchResults.Select(converter));
 

--- a/src/Novell.Directory.Ldap.NETStandard/SearchExtensions/VirtualListViewControlHandler.cs
+++ b/src/Novell.Directory.Ldap.NETStandard/SearchExtensions/VirtualListViewControlHandler.cs
@@ -3,6 +3,7 @@ using Novell.Directory.Ldap.Controls;
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace Novell.Directory.Ldap.SearchExtensions
@@ -23,7 +24,8 @@ namespace Novell.Directory.Ldap.SearchExtensions
         public Task<List<LdapEntry>> SearchUsingVlvAsync(
             [NotNull] LdapSortControl sortControl,
             [NotNull] SearchOptions options,
-            int pageSize)
+            int pageSize,
+            CancellationToken cancellationToken = default)
         {
             if (sortControl == null)
             {
@@ -40,14 +42,15 @@ namespace Novell.Directory.Ldap.SearchExtensions
                 throw new ArgumentOutOfRangeException(nameof(pageSize));
             }
 
-            return SearchUsingVlvAsync(sortControl, entry => entry, options, pageSize);
+            return SearchUsingVlvAsync(sortControl, entry => entry, options, pageSize, cancellationToken);
         }
 
         public async Task<List<T>> SearchUsingVlvAsync<T>(
             [NotNull] LdapSortControl sortControl,
             [NotNull] Func<LdapEntry, T> converter,
             [NotNull] SearchOptions options,
-            int pageSize)
+            int pageSize,
+            CancellationToken cancellationToken = default)
         {
             if (sortControl == null)
             {
@@ -89,7 +92,7 @@ namespace Novell.Directory.Ldap.SearchExtensions
                     options.TypesOnly,
                     searchConstraints).ConfigureAwait(false);
 
-                var searchResults = await asyncSearchResults.ToListAsync().ConfigureAwait(false);
+                var searchResults = await asyncSearchResults.ToListAsync(cancellationToken).ConfigureAwait(false);
 
                 entries.AddRange(searchResults.Select(converter));
 

--- a/src/Novell.Directory.Ldap.NETStandard/SearchExtensions/VirtualListViewControlSearchExtensions.cs
+++ b/src/Novell.Directory.Ldap.NETStandard/SearchExtensions/VirtualListViewControlSearchExtensions.cs
@@ -2,6 +2,7 @@
 using Novell.Directory.Ldap.Controls;
 using System;
 using System.Collections.Generic;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace Novell.Directory.Ldap.SearchExtensions
@@ -16,7 +17,8 @@ namespace Novell.Directory.Ldap.SearchExtensions
             [NotNull] this ILdapConnection ldapConnection,
             [NotNull] LdapSortControl sortControl,
             [NotNull] SearchOptions options,
-            int pageSize)
+            int pageSize,
+            CancellationToken cancellationToken = default)
         {
             if (ldapConnection == null)
             {
@@ -39,7 +41,7 @@ namespace Novell.Directory.Ldap.SearchExtensions
             }
 
             return new VirtualListViewControlHandler(ldapConnection)
-                .SearchUsingVlvAsync(sortControl, options, pageSize);
+                .SearchUsingVlvAsync(sortControl, options, pageSize, cancellationToken);
         }
 
         public static Task<List<T>> SearchUsingVlvAsync<T>(
@@ -47,7 +49,8 @@ namespace Novell.Directory.Ldap.SearchExtensions
             [NotNull] LdapSortControl sortControl,
             [NotNull] Func<LdapEntry, T> converter,
             [NotNull] SearchOptions options,
-            int pageSize)
+            int pageSize,
+            CancellationToken cancellationToken = default)
         {
             if (ldapConnection == null)
             {
@@ -70,7 +73,7 @@ namespace Novell.Directory.Ldap.SearchExtensions
             }
 
             return new VirtualListViewControlHandler(ldapConnection)
-                .SearchUsingVlvAsync<T>(sortControl, converter, options, pageSize);
+                .SearchUsingVlvAsync<T>(sortControl, converter, options, pageSize, cancellationToken);
         }
     }
 }

--- a/test/Novell.Directory.Ldap.NETStandard.FunctionalTests/SearchTests.cs
+++ b/test/Novell.Directory.Ldap.NETStandard.FunctionalTests/SearchTests.cs
@@ -18,7 +18,7 @@ namespace Novell.Directory.Ldap.NETStandard.FunctionalTests
                 async ldapConnection =>
                 {
                     var lsc = await ldapConnection.SearchAsync(TestsConfig.LdapServer.BaseDn, LdapConnection.ScopeSub, "cn=" + ldapEntry.GetAttribute("cn").StringValue, null, false);
-                    var entries = lsc.ToList();
+                    var entries = await lsc.ToListAsync();
 
                     Assert.Single(entries);
                     ldapEntry.AssertSameAs(entries[0]);


### PR DESCRIPTION
This will drop support for .netstandard 1.3 and will use IAsyncEnumerable in LdapSearchResults to get rid of .GetAwaiter for this.

Solves issue: https://github.com/dsbenghe/Novell.Directory.Ldap.NETStandard/issues/155