### PR TITLE
Set MatchingRules, Collective, UserModifiable and Usage properties when creating LdapAttributeSchema from definition string

### DIFF
--- a/src/Novell.Directory.Ldap.NETStandard/LdapAttributeSchema.cs
+++ b/src/Novell.Directory.Ldap.NETStandard/LdapAttributeSchema.cs
@@ -182,6 +182,25 @@ namespace Novell.Directory.Ldap
                     Superior = parser.Superior;
                 }
 
+                if (parser.Equality != null)
+                {
+                    EqualityMatchingRule = parser.Equality;
+                }
+
+                if (parser.Ordering != null)
+                {
+                    OrderingMatchingRule = parser.Ordering;
+                }
+
+                if (parser.Substring != null)
+                {
+                    SubstringMatchingRule = parser.Substring;
+                }
+
+                Collective = parser.Collective;
+                UserModifiable = parser.UserMod;
+                Usage = parser.Usage;
+
                 SingleValued = parser.Single;
                 Obsolete = parser.Obsolete;
                 var qualifiers = parser.Qualifiers;


### PR DESCRIPTION
Creating an `LdapAttributeSchema` from a raw string definition didn't set EqualityMatchingRule, OrderingMatchingRule, SubstringMatchingRule, Collective, UserModifiable and Usage properties.
The original (2003-)Novell library, erroneously, didn't set these either.