### PR TITLE
Remove dependency on System.Linq.Async

### DIFF
--- a/src/Novell.Directory.Ldap.NETStandard/Novell.Directory.Ldap.NETStandard.csproj
+++ b/src/Novell.Directory.Ldap.NETStandard/Novell.Directory.Ldap.NETStandard.csproj
@@ -57,7 +57,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="System.Linq.Async" Version="5.0.0" />
     <PackageReference Include="AsyncFixer" Version="1.1.6">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/src/Novell.Directory.Ldap.NETStandard/SearchExtensions/SimplePagedResultsControlHandler.cs
+++ b/src/Novell.Directory.Ldap.NETStandard/SearchExtensions/SimplePagedResultsControlHandler.cs
@@ -1,5 +1,6 @@
 ﻿using JetBrains.Annotations;
 using Novell.Directory.Ldap.Controls;
+using Novell.Directory.Ldap.Utilclass;
 using System;
 using System.Collections.Generic;
 using System.Linq;

--- a/src/Novell.Directory.Ldap.NETStandard/SearchExtensions/VirtualListViewControlHandler.cs
+++ b/src/Novell.Directory.Ldap.NETStandard/SearchExtensions/VirtualListViewControlHandler.cs
@@ -1,5 +1,6 @@
 ﻿using JetBrains.Annotations;
 using Novell.Directory.Ldap.Controls;
+using Novell.Directory.Ldap.Utilclass;
 using System;
 using System.Collections.Generic;
 using System.Linq;

--- a/src/Novell.Directory.Ldap.NETStandard/Utilclass/AsyncEnumerableExtensions.cs
+++ b/src/Novell.Directory.Ldap.NETStandard/Utilclass/AsyncEnumerableExtensions.cs
@@ -1,0 +1,24 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Novell.Directory.Ldap.Utilclass
+{
+    public static class AsyncEnumerableExtensions
+    {
+        /// <summary>
+        /// Asynchronously materializes the subject <see cref="IAsyncEnumerable{T}"/> into a list.
+        /// </summary>
+        public static async Task<List<T>> ToListAsync<T>(this IAsyncEnumerable<T> enumerable, CancellationToken cancellationToken = default)
+        {
+            var list = new List<T>();
+            await foreach (var element in enumerable.WithCancellation(cancellationToken))
+            {
+                list.Add(element);
+            }
+
+            return list;
+        }
+    }
+}

--- a/test/Novell.Directory.Ldap.NETStandard.FunctionalTests/SearchTests.cs
+++ b/test/Novell.Directory.Ldap.NETStandard.FunctionalTests/SearchTests.cs
@@ -1,4 +1,5 @@
 ﻿using Novell.Directory.Ldap.NETStandard.FunctionalTests.Helpers;
+using Novell.Directory.Ldap.Utilclass;
 using System;
 using System.Linq;
 using System.Threading.Tasks;


### PR DESCRIPTION
System.Linq.Async appears to be used exclusively to provide ToListAsync, which is ridiculous as it is trivial to implement.

It also introduces extension methods into the System.Linq namespace which conflict with common EntityFrameworkCore usage patterns, as DbSet&lt;T&gt; implements both IAsyncEnumerable&lt;T&gt; and IQueryable&lt;T&gt;. This most often manifests itself as a conflict between:

```cs
System.Linq.AsyncEnumerable.Where<T>(this IAsyncEnumerable<T>, Func<T, bool>)
```

and

```cs
System.Linq.Queryable.Where(this IQueryable<T>, Expression<Func<T, bool>>)
```

You can watch both Microsoft teams blame each other here:

https://github.com/dotnet/reactive/issues/1057
https://github.com/dotnet/efcore/issues/18124