### PR TITLE
Change access modifier for AsyncEnumerableExtensions.ToListAsync

### DIFF
--- a/src/Novell.Directory.Ldap.NETStandard/Utilclass/AsyncEnumerableExtensions.cs
+++ b/src/Novell.Directory.Ldap.NETStandard/Utilclass/AsyncEnumerableExtensions.cs
@@ -10,7 +10,7 @@ namespace Novell.Directory.Ldap.Utilclass
         /// <summary>
         /// Asynchronously materializes the subject <see cref="IAsyncEnumerable{T}"/> into a list.
         /// </summary>
-        public static async Task<List<T>> ToListAsync<T>(this IAsyncEnumerable<T> enumerable, CancellationToken cancellationToken = default)
+        internal static async Task<List<T>> ToListAsync<T>(this IAsyncEnumerable<T> enumerable, CancellationToken cancellationToken = default)
         {
             var list = new List<T>();
             await foreach (var element in enumerable.WithCancellation(cancellationToken))

--- a/test/Novell.Directory.Ldap.NETStandard.FunctionalTests/Novell.Directory.Ldap.NETStandard.FunctionalTests.csproj
+++ b/test/Novell.Directory.Ldap.NETStandard.FunctionalTests/Novell.Directory.Ldap.NETStandard.FunctionalTests.csproj
@@ -24,6 +24,7 @@
     <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="3.1.4" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="3.1.4" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.8.0" />
+    <PackageReference Include="System.Linq.Async" Version="6.0.1" />
     <PackageReference Include="System.Runtime.Serialization.Primitives" Version="4.3.0" />
     <PackageReference Include="xunit" Version="2.4.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />


### PR DESCRIPTION
Change the access modifier for AsyncEnumerableExtensions.ToListAsync from `public` to `internal`.

Doing this removes ambiguity in projects dependent on System.Linq.Async to utilize ILdapSearchResults..
Additionally add dependency on System.Linq.Async for FunctionalTests to maintain functionality.
Closes #250.

