### PR TITLE
Rework Tokenizer

### DIFF
--- a/test/Novell.Directory.Ldap.NETStandard.UnitTests/TokenizerTests.cs
+++ b/test/Novell.Directory.Ldap.NETStandard.UnitTests/TokenizerTests.cs
@@ -1,0 +1,59 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Xunit;
+
+namespace Novell.Directory.Ldap.NETStandard.UnitTests
+{
+    public class TokenizerTests
+    {
+        [Theory]
+        [InlineData("", ".", false, new string[0])]
+        [InlineData("", ".", true, new string[0])]
+        [InlineData(".", ".", false, new string[0])]
+        [InlineData(".", ".", true, new string[0])]
+        [InlineData("..", ".", false, new string[0])]
+        [InlineData("..", ".", true, new[] { "." })]
+        [InlineData(".,", ".,", false, new string[0])]
+        [InlineData(".,", ".,", true, new[] { "." })]
+        [InlineData("a", ".", false, new[] { "a" })]
+        [InlineData("a", ".", true, new[] { "a" })]
+        [InlineData("a.", ".", false, new[] { "a" })]
+        [InlineData("a.", ".", true, new[] { "a", "." })]
+        [InlineData("a..", ".", false, new[] { "a" })]
+        [InlineData("a..", ".", true, new[] { "a", "." })]
+        [InlineData("a..b", ".", false, new[] { "a", "b" })]
+        [InlineData("a..b", ".", true, new[] { "a", ".", ".", "b" })]
+        [InlineData("a.,b", ".,", false, new[] { "a", "b" })]
+        [InlineData("a.,b", ".,", true, new[] { "a", ".", ",", "b" })]
+        [InlineData("a.b.", ".", false, new[] { "a", "b" })]
+        [InlineData("a.b.", ".", true, new[] { "a", ".", "b", "." })]
+        [InlineData("a.b..", ".", false, new[] { "a", "b" })]
+        [InlineData("a.b..", ".", true, new[] { "a", ".", "b", "." })]
+        [InlineData("a.b.,", ".,", false, new[] { "a", "b" })]
+        [InlineData("a.b.,", ".,", true, new[] { "a", ".", "b", "." })]
+        [InlineData("a.b.c", ".", false, new[] { "a", "b", "c" })]
+        [InlineData("a.b.c", ".", true, new[] { "a", ".", "b", ".", "c" })]
+        [InlineData(".b.c", ".", false, new[] { "b", "c" })]
+        [InlineData(".b.c", ".", true, new[] { ".", "b", ".", "c" })]
+        [InlineData("..c", ".", false, new[] { "c" })]
+        [InlineData("..c", ".", true, new[] { ".", ".", "c" })]
+        [InlineData(".,c", ".,", false, new[] { "c" })]
+        [InlineData(".,c", ".,", true, new[] { ".", ",", "c" })]
+        public void StringGetsTokenized(string source, string delimiters, bool returnDelimiters, string[] tokens)
+        {
+            var tokenizer = new Tokenizer(source, delimiters, returnDelimiters);
+
+            Assert.Equal(tokens.Length, tokenizer.Count);
+
+            for (var i = 0; i < tokens.Length; i++)
+            {
+                Assert.True(tokenizer.HasMoreTokens(), $"Next should be tokens[{i}]: {tokens[i]}");
+                Assert.Equal(tokens[i], tokenizer.NextToken());
+            }
+
+            Assert.False(tokenizer.HasMoreTokens());
+        }
+    }
+}


### PR DESCRIPTION
I reworked Tokenizer, trying to remove the repeated splitting, as the elements were all already there and utilizing the built-in `StringSplitOptions.RemoveEmptyEntries`.

In doing this I found, that the current implementation would return a string twice, if it does not contain delimiters and the tokenizer is asked to return the delimiters. This is cause by `Tokenize()` not returning or setting `tempstr` to empty after `if (tempstr.IndexOfAny(_delimiters.ToCharArray()) < 0 && tempstr.Length > 0)`, so that it is added again by the last `if` in that method.