### PR TITLE
Try to copy less

### DIFF
--- a/src/Novell.Directory.Ldap.NETStandard/Asn1/Asn1Structured.cs
+++ b/src/Novell.Directory.Ldap.NETStandard/Asn1/Asn1Structured.cs
@@ -128,10 +128,7 @@ namespace Novell.Directory.Ldap.Asn1
             if (_contentIndex == _content.Length)
             {
                 // Array too small, need to expand it, double length
-                var newSize = _contentIndex + _contentIndex;
-                var newArray = new Asn1Object[newSize];
-                Array.Copy(_content, 0, newArray, 0, _contentIndex);
-                _content = newArray;
+                Array.Resize(ref _content, _contentIndex + _contentIndex);
             }
 
             _content[_contentIndex++] = valueRenamed;

--- a/src/Novell.Directory.Ldap.NETStandard/LdapExtendedOperation.cs
+++ b/src/Novell.Directory.Ldap.NETStandard/LdapExtendedOperation.cs
@@ -62,14 +62,14 @@ namespace Novell.Directory.Ldap
         /// <returns>
         ///     clone of this object.
         /// </returns>
-        public object Clone()
+        public LdapExtendedOperation Clone()
         {
             try
             {
-                var newObj = MemberwiseClone();
+                var newObj = (LdapExtendedOperation)MemberwiseClone();
 
                 // Array.Copy((System.Array)SupportClass.ToByteArray( this.vals), 0, (System.Array)SupportClass.ToByteArray( ((LdapExtendedOperation) newObj).vals), 0, this.vals.Length);
-                Array.Copy(_vals, 0, ((LdapExtendedOperation)newObj)._vals, 0, _vals.Length);
+                newObj._vals = (byte[])_vals.Clone();
                 return newObj;
             }
             catch (Exception ce)

--- a/src/Novell.Directory.Ldap.NETStandard/Novell.Directory.Ldap.NETStandard.csproj
+++ b/src/Novell.Directory.Ldap.NETStandard/Novell.Directory.Ldap.NETStandard.csproj
@@ -39,6 +39,7 @@
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="2.2.0" />
     <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="5.0.0" />
+    <PackageReference Include="System.Memory" Version="4.5.5" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.1'">

--- a/src/Novell.Directory.Ldap.NETStandard/Utilclass/ByteArrayAsUtf8StringView.cs
+++ b/src/Novell.Directory.Ldap.NETStandard/Utilclass/ByteArrayAsUtf8StringView.cs
@@ -1,0 +1,37 @@
+﻿using System.Collections.Generic;
+
+namespace Novell.Directory.Ldap.Utilclass
+{
+    /// <summary>
+    /// Provides a readonly list-view over a <c>byte[][]</c>-value.
+    /// Returned values are UTF-8-decoded strings of the values of the backing array.
+    /// </summary>
+    public sealed class ByteArrayAsUtf8StringView : ViewBase<byte[], string>
+    {
+        public ByteArrayAsUtf8StringView(IReadOnlyList<byte[]> byteValues)
+            : base(byteValues)
+        {
+        }
+
+        public override string this[int index] => InnerValues[index].ToUtf8String();
+
+        public override int IndexOf(string item)
+        {
+            if (item == null)
+            {
+                return -1;
+            }
+
+            for (int i = 0; i < InnerValues.Count; i++)
+            {
+                var value = this[i];
+                if (string.Equals(value, item))
+                {
+                    return i;
+                }
+            }
+
+            return -1;
+        }
+    }
+}

--- a/src/Novell.Directory.Ldap.NETStandard/Utilclass/ByteArrayView.cs
+++ b/src/Novell.Directory.Ldap.NETStandard/Utilclass/ByteArrayView.cs
@@ -1,0 +1,43 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Novell.Directory.Ldap.Utilclass
+{
+    /// <summary>
+    /// Provides a readonly list-view over a <c>byte[][]</c>-value.
+    /// Returned values are copies of the values of the backing array, and hence modifing them does not change the original value.
+    /// </summary>
+    public sealed class ByteArrayView : ViewBase<byte[], byte[]>
+    {
+        public ByteArrayView(IReadOnlyList<byte[]> byteValues)
+            : base(byteValues)
+        {
+        }
+
+        public override byte[] this[int index] => (byte[])InnerValues[index].Clone();
+
+        public ReadOnlySpan<byte> GetAsSpan(int index)
+        {
+            return InnerValues[index];
+        }
+
+        public override int IndexOf(byte[] item)
+        {
+            if (item == null)
+            {
+                return -1;
+            }
+
+            for (int i = 0; i < InnerValues.Count; i++)
+            {
+                if (InnerValues[i].SequenceEqual(item))
+                {
+                    return i;
+                }
+            }
+
+            return -1;
+        }
+    }
+}

--- a/src/Novell.Directory.Ldap.NETStandard/Utilclass/ViewBase.cs
+++ b/src/Novell.Directory.Ldap.NETStandard/Utilclass/ViewBase.cs
@@ -1,0 +1,79 @@
+﻿using System;
+using System.Collections;
+using System.Collections.Generic;
+
+namespace Novell.Directory.Ldap.Utilclass;
+
+public abstract class ViewBase<TIn, TOut> : IReadOnlyList<TOut>, IList<TOut>
+{
+    protected IReadOnlyList<TIn> InnerValues { get; }
+
+    public ViewBase(IReadOnlyList<TIn> innerValues)
+    {
+        InnerValues = innerValues ?? Array.Empty<TIn>();
+    }
+
+    public bool IsReadOnly => true;
+    public int Count => InnerValues.Count;
+
+    public abstract TOut this[int index] { get; }
+
+    TOut IList<TOut>.this[int index]
+    {
+        get => this[index];
+        set => throw new NotSupportedException();
+    }
+
+    public IEnumerator<TOut> GetEnumerator()
+    {
+        for (int i = 0; i < InnerValues.Count; i++)
+        {
+            yield return this[i];
+        }
+    }
+
+    IEnumerator IEnumerable.GetEnumerator()
+    {
+        return GetEnumerator();
+    }
+
+    public void CopyTo(TOut[] array, int arrayIndex)
+    {
+        for (var i = 0; i < InnerValues.Count; i++)
+        {
+            array[arrayIndex + i] = this[i];
+        }
+    }
+
+    public abstract int IndexOf(TOut item);
+
+    public bool Contains(TOut item)
+    {
+        return IndexOf(item) >= 0;
+    }
+
+    void IList<TOut>.Insert(int index, TOut item)
+    {
+        throw new NotSupportedException();
+    }
+
+    void IList<TOut>.RemoveAt(int index)
+    {
+        throw new NotSupportedException();
+    }
+
+    void ICollection<TOut>.Add(TOut item)
+    {
+        throw new NotSupportedException();
+    }
+
+    void ICollection<TOut>.Clear()
+    {
+        throw new NotSupportedException();
+    }
+
+    bool ICollection<TOut>.Remove(TOut item)
+    {
+        throw new NotSupportedException();
+    }
+}


### PR DESCRIPTION
Especially when interacting with LdapAttribute currently many copies are made. Introducing ByteArrayView and ByteArrayAsUtf8StringView allows us to give out IReadOnlyList-Representations of the values, without copying them before they are actually accessed. In addition I tried to reduce the amount of code used to resize and copy arrays, where the runtime now provides ways to do so.