### PR TITLE
Add nullable reference types to LdapEntry.cs

### DIFF
--- a/build/Novell.Directory.Ldap.NETStandard.ruleset
+++ b/build/Novell.Directory.Ldap.NETStandard.ruleset
@@ -69,6 +69,7 @@
     <Rule Id="CA2242" Action="Warning" />
   </Rules>
   <Rules AnalyzerId="StyleCop.Analyzers" RuleNamespace="StyleCop.Analyzers">
+    <Rule Id="SA1011" Action="None" />  <!-- A closing square bracket within a C# statement is not spaced correctly. -->
     <Rule Id="SA1024" Action="None" />  <!-- Colon must not be preceded by a space. -->
     <Rule Id="SA1101" Action="None" />  <!-- A call to an instance member of the local class or a base class is not prefixed with ‘this.’, within a C# code file; this is conflicting with the Varian style guidelines. -->
     <Rule Id="SX1101" Action="Error" /> <!-- Do not prefix local calls with 'this.' -->

--- a/src/Novell.Directory.Ldap.NETStandard/LdapEntry.cs
+++ b/src/Novell.Directory.Ldap.NETStandard/LdapEntry.cs
@@ -21,6 +21,8 @@
 * SOFTWARE.
 *******************************************************************************/
 
+#nullable enable
+
 using System;
 using System.Text;
 
@@ -55,7 +57,7 @@ namespace Novell.Directory.Ldap
         ///     The initial set of attributes assigned to the
         ///     entry.
         /// </param>
-        public LdapEntry(string dn = null, LdapAttributeSet attrs = null)
+        public LdapEntry(string? dn = null, LdapAttributeSet? attrs = null)
         {
             dn ??= string.Empty;
 
@@ -87,8 +89,13 @@ namespace Novell.Directory.Ldap
         ///     A negative integer, zero, or a positive integer as this
         ///     object is less than, equal to, or greater than the specified object.
         /// </returns>
-        public virtual int CompareTo(object entry)
+        public virtual int CompareTo(object? entry)
         {
+            if (entry == null)
+            {
+                return 1;
+            }
+
             return LdapDn.Normalize(Dn).CompareTo(LdapDn.Normalize(((LdapEntry)entry).Dn));
         }
 
@@ -129,7 +136,7 @@ namespace Novell.Directory.Ldap
         /// <returns>
         ///     A LdapAttribute.
         /// </returns>
-        public LdapAttribute GetOrDefault(string attributeName, LdapAttribute fallback = default)
+        public LdapAttribute? GetOrDefault(string attributeName, LdapAttribute? fallback = default)
         {
             return !Attrs.TryGetValue(attributeName, out var attribute) ? fallback : attribute;
         }
@@ -143,7 +150,7 @@ namespace Novell.Directory.Ldap
         /// <returns>
         ///     The string attribute value.
         /// </returns>
-        public string GetStringValueOrDefault(string attributeName, string fallback = default)
+        public string? GetStringValueOrDefault(string attributeName, string? fallback = default)
         {
             return GetOrDefault(attributeName)?.StringValue ?? fallback;
         }
@@ -157,7 +164,7 @@ namespace Novell.Directory.Ldap
         /// <returns>
         ///     The byte[] attribute value.
         /// </returns>
-        public byte[] GetBytesValueOrDefault(string attributeName, byte[] fallback = default)
+        public byte[]? GetBytesValueOrDefault(string attributeName, byte[]? fallback = default)
         {
             return GetOrDefault(attributeName)?.ByteValue ?? fallback;
         }

--- a/src/Novell.Directory.Ldap.NETStandard/Novell.Directory.Ldap.NETStandard.csproj
+++ b/src/Novell.Directory.Ldap.NETStandard/Novell.Directory.Ldap.NETStandard.csproj
@@ -7,6 +7,7 @@
     <VersionPrefix>4.0.0-beta6</VersionPrefix>
     <Authors>Novell;dsbenghe</Authors>
     <TargetFrameworks>netstandard2.0;netstandard2.1;net6;net7;net8</TargetFrameworks>
+    <Nullable>disable</Nullable>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <AssemblyName>Novell.Directory.Ldap.NETStandard</AssemblyName>
     <PackageId>Novell.Directory.Ldap.NETStandard</PackageId>

--- a/test/Novell.Directory.Ldap.NETStandard.UnitTests/LdapEntryTests.cs
+++ b/test/Novell.Directory.Ldap.NETStandard.UnitTests/LdapEntryTests.cs
@@ -37,6 +37,12 @@ public class LdapEntryTests
     }
 
     [Fact]
+    public void GetOrDefault_when_not_exists_without_fallback_returns_null()
+    {
+        Assert.Null(_ldapEntry.GetOrDefault("givenName_1"));
+    }
+
+    [Fact]
     public void GetStringValueOrDefault_when_exists_returns_string_value()
     {
         Assert.Equal("Lionel", _ldapEntry.GetStringValueOrDefault("givenName"));
@@ -50,6 +56,12 @@ public class LdapEntryTests
     }
 
     [Fact]
+    public void GetStringValueOrDefault_when_not_exists_without_fallback_returns_null()
+    {
+        Assert.Null(_ldapEntry.GetStringValueOrDefault("givenName_1"));
+    }
+
+    [Fact]
     public void GetBytesOrDefault_when_exists_returns_string_value()
     {
         Assert.Equal(new byte[] { 1, 2 }, _ldapEntry.GetBytesValueOrDefault("bytes"));
@@ -60,6 +72,12 @@ public class LdapEntryTests
     {
         var fallback = new byte[] { 1, 2, 3 };
         Assert.Equal(fallback, _ldapEntry.GetBytesValueOrDefault("bytes_1", fallback));
+    }
+
+    [Fact]
+    public void GetBytesOrDefault_when_not_exists_without_fallback_returns_null()
+    {
+        Assert.Null(_ldapEntry.GetBytesValueOrDefault("bytes_1"));
     }
 
     public static LdapEntry NewLdapEntry(string cnPrefix = null)


### PR DESCRIPTION
As discussed in #264
Also set nullable compiler flag to "disable". This is the same as omitting it, just making it more clear as nullable gets implemented.