### PR TITLE
Renames/style cleanup.

### DIFF
--- a/src/Novell.Directory.Ldap.NETStandard/Asn1/Asn1Boolean.cs
+++ b/src/Novell.Directory.Ldap.NETStandard/Asn1/Asn1Boolean.cs
@@ -66,13 +66,13 @@ namespace Novell.Directory.Ldap.Asn1
         ///     input stream.  Sometimes a developer might want to pass
         ///     in his/her own decoder object.
         /// </param>
-        /// <param name="inRenamed">
+        /// <param name="input">
         ///     A byte stream that contains the encoded ASN.1.
         /// </param>
-        public Asn1Boolean(IAsn1Decoder dec, Stream inRenamed, int len)
+        public Asn1Boolean(IAsn1Decoder dec, Stream input, int len)
             : base(Id)
         {
-            _content = dec.DecodeBoolean(inRenamed, len);
+            _content = dec.DecodeBoolean(input, len);
         }
 
         /* Asn1Object implementation
@@ -85,13 +85,13 @@ namespace Novell.Directory.Ldap.Asn1
         /// <param name="enc">
         ///     Encoder object to use when encoding self.
         /// </param>
-        /// <param name="outRenamed">
+        /// <param name="output">
         ///     The output stream onto which the encoded byte
         ///     stream is written.
         /// </param>
-        public override void Encode(IAsn1Encoder enc, Stream outRenamed)
+        public override void Encode(IAsn1Encoder enc, Stream output)
         {
-            enc.Encode(this, outRenamed);
+            enc.Encode(this, output);
         }
 
         /* Asn1Boolean specific methods

--- a/src/Novell.Directory.Ldap.NETStandard/Asn1/Asn1Boolean.cs
+++ b/src/Novell.Directory.Ldap.NETStandard/Asn1/Asn1Boolean.cs
@@ -72,7 +72,7 @@ namespace Novell.Directory.Ldap.Asn1
         public Asn1Boolean(IAsn1Decoder dec, Stream inRenamed, int len)
             : base(Id)
         {
-            _content = (bool)dec.DecodeBoolean(inRenamed, len);
+            _content = dec.DecodeBoolean(inRenamed, len);
         }
 
         /* Asn1Object implementation

--- a/src/Novell.Directory.Ldap.NETStandard/Asn1/Asn1Choice.cs
+++ b/src/Novell.Directory.Ldap.NETStandard/Asn1/Asn1Choice.cs
@@ -60,17 +60,15 @@ namespace Novell.Directory.Ldap.Asn1
             ChoiceValue = null;
         }
 
-#pragma warning disable CS1572 // XML comment has a param tag, but there is no parameter by that name
         /// <summary>
         ///     Sets the CHOICE value stored in this Asn1Choice.
         /// </summary>
-        /// <param name="content">
+        /// <param name="value">
         ///     The Asn1Object that this Asn1Choice will
         ///     encode.  Since all Asn1 objects are derived from Asn1Object
         ///     any basic type can be passed in.
         /// </param>
         protected Asn1Object ChoiceValue { get; set; }
-#pragma warning restore CS1572 // XML comment has a param tag, but there is no parameter by that name
 
         /* Asn1Object implementation
         */
@@ -83,13 +81,13 @@ namespace Novell.Directory.Ldap.Asn1
         /// <param name="enc">
         ///     Encoder object to use when encoding self.
         /// </param>
-        /// <param name="outRenamed">
+        /// <param name="output">
         ///     The output stream onto which the encoded byte
         ///     stream is written.
         /// </param>
-        public override void Encode(IAsn1Encoder enc, Stream outRenamed)
+        public override void Encode(IAsn1Encoder enc, Stream output)
         {
-            ChoiceValue.Encode(enc, outRenamed);
+            ChoiceValue.Encode(enc, output);
         }
 
         /* Asn1Choice specific methods

--- a/src/Novell.Directory.Ldap.NETStandard/Asn1/Asn1Decoder.cs
+++ b/src/Novell.Directory.Ldap.NETStandard/Asn1/Asn1Decoder.cs
@@ -66,9 +66,9 @@ namespace Novell.Directory.Ldap.Asn1
         ///     type has decoded all of its components.
         /// </param>
         /// <param name="input">
-        ///     An input stream containig the encoded ASN.1 data.
+        ///     An input stream containing the encoded ASN.1 data.
         /// </param>
-        Asn1Object Decode(Stream input, int[] length);
+        Asn1Object Decode(Stream input, out int length);
 
         /* Decoders for ASN.1 simple types
         */

--- a/src/Novell.Directory.Ldap.NETStandard/Asn1/Asn1Decoder.cs
+++ b/src/Novell.Directory.Ldap.NETStandard/Asn1/Asn1Decoder.cs
@@ -43,18 +43,18 @@ namespace Novell.Directory.Ldap.Asn1
         /// <summary>
         ///     Decode an encoded value into an Asn1Object from a byte array.
         /// </summary>
-        /// <param name="valueRenamed">
+        /// <param name="value">
         ///     A byte array that points to the encoded Asn1 data.
         /// </param>
-        Asn1Object Decode(byte[] valueRenamed);
+        Asn1Object Decode(byte[] value);
 
         /// <summary>
         ///     Decode an encoded value into an Asn1Object from an InputStream.
         /// </summary>
-        /// <param name="inRenamed">
+        /// <param name="input">
         ///     An input stream containig the encoded ASN.1 data.
         /// </param>
-        Asn1Object Decode(Stream inRenamed);
+        Asn1Object Decode(Stream input);
 
         /// <summary>
         ///     Decode an encoded value into an Asn1Object from an InputStream.
@@ -65,10 +65,10 @@ namespace Novell.Directory.Ldap.Asn1
         ///     the number of bytes decoded, so you know when the structured
         ///     type has decoded all of its components.
         /// </param>
-        /// <param name="inRenamed">
+        /// <param name="input">
         ///     An input stream containig the encoded ASN.1 data.
         /// </param>
-        Asn1Object Decode(Stream inRenamed, int[] length);
+        Asn1Object Decode(Stream input, int[] length);
 
         /* Decoders for ASN.1 simple types
         */
@@ -77,26 +77,26 @@ namespace Novell.Directory.Ldap.Asn1
         ///     Decode a BOOLEAN directly from a stream. Call this method when you
         ///     know that the next ASN.1 encoded element is a BOOLEAN.
         /// </summary>
-        /// <param name="inRenamed">
+        /// <param name="input">
         ///     An input stream containig the encoded ASN.1 data.
         /// </param>
         /// <param name="len">
         ///     Length in bytes.
         /// </param>
-        bool DecodeBoolean(Stream inRenamed, int len);
+        bool DecodeBoolean(Stream input, int len);
 
         /// <summary>
         ///     Decode a Numeric value directly from a stream.  Call this method when you
         ///     know that the next ASN.1 encoded element is a Numeric
         ///     Can be used to decodes INTEGER and ENUMERATED types.
         /// </summary>
-        /// <param name="inRenamed">
-        ///     An input stream containig the encoded ASN.1 data.
+        /// <param name="input">
+        ///     An input stream containing the encoded ASN.1 data.
         /// </param>
         /// <param name="len">
         ///     Length in bytes.
         /// </param>
-        long DecodeNumeric(Stream inRenamed, int len);
+        long DecodeNumeric(Stream input, int len);
 
         /* Asn1 TYPE NOT YET SUPPORTED
                     * Decode a REAL directly from a stream.
@@ -113,13 +113,13 @@ namespace Novell.Directory.Ldap.Asn1
         ///     Decode an OCTET_STRING directly from a stream. Call this method when you
         ///     know that the next ASN.1 encoded element is a OCTET_STRING.
         /// </summary>
-        /// <param name="inRenamed">
+        /// <param name="input">
         ///     An input stream containig the encoded ASN.1 data.
         /// </param>
         /// <param name="len">
         ///     Length in bytes.
         /// </param>
-        byte[] DecodeOctetString(Stream inRenamed, int len);
+        byte[] DecodeOctetString(Stream input, int len);
 
         /* Asn1 TYPE NOT YET SUPPORTED
                     * Decode an OBJECT_IDENTIFIER directly from a stream.
@@ -131,13 +131,13 @@ namespace Novell.Directory.Ldap.Asn1
         ///     Decode a CharacterString directly from a stream.
         ///     Decodes any of the specialized character strings.
         /// </summary>
-        /// <param name="inRenamed">
+        /// <param name="input">
         ///     An input stream containig the encoded ASN.1 data.
         /// </param>
         /// <param name="len">
         ///     Length in bytes.
         /// </param>
-        string DecodeCharacterString(Stream inRenamed, int len);
+        string DecodeCharacterString(Stream input, int len);
 
         /* No Decoders for ASN.1 structured types. A structured type's value is a
         * collection of other types.

--- a/src/Novell.Directory.Ldap.NETStandard/Asn1/Asn1Decoder.cs
+++ b/src/Novell.Directory.Ldap.NETStandard/Asn1/Asn1Decoder.cs
@@ -83,7 +83,7 @@ namespace Novell.Directory.Ldap.Asn1
         /// <param name="len">
         ///     Length in bytes.
         /// </param>
-        object DecodeBoolean(Stream inRenamed, int len);
+        bool DecodeBoolean(Stream inRenamed, int len);
 
         /// <summary>
         ///     Decode a Numeric value directly from a stream.  Call this method when you
@@ -96,7 +96,7 @@ namespace Novell.Directory.Ldap.Asn1
         /// <param name="len">
         ///     Length in bytes.
         /// </param>
-        object DecodeNumeric(Stream inRenamed, int len);
+        long DecodeNumeric(Stream inRenamed, int len);
 
         /* Asn1 TYPE NOT YET SUPPORTED
                     * Decode a REAL directly from a stream.
@@ -119,7 +119,7 @@ namespace Novell.Directory.Ldap.Asn1
         /// <param name="len">
         ///     Length in bytes.
         /// </param>
-        object DecodeOctetString(Stream inRenamed, int len);
+        byte[] DecodeOctetString(Stream inRenamed, int len);
 
         /* Asn1 TYPE NOT YET SUPPORTED
                     * Decode an OBJECT_IDENTIFIER directly from a stream.
@@ -137,7 +137,7 @@ namespace Novell.Directory.Ldap.Asn1
         /// <param name="len">
         ///     Length in bytes.
         /// </param>
-        object DecodeCharacterString(Stream inRenamed, int len);
+        string DecodeCharacterString(Stream inRenamed, int len);
 
         /* No Decoders for ASN.1 structured types. A structured type's value is a
         * collection of other types.

--- a/src/Novell.Directory.Ldap.NETStandard/Asn1/Asn1Encoder.cs
+++ b/src/Novell.Directory.Ldap.NETStandard/Asn1/Asn1Encoder.cs
@@ -48,11 +48,11 @@ namespace Novell.Directory.Ldap.Asn1
         /// <param name="b">
         ///     The Asn1Boolean object to encode.
         /// </param>
-        /// <param name="outRenamed">
+        /// <param name="output">
         ///     The output stream onto which the ASN.1 object is
         ///     to be encoded.
         /// </param>
-        void Encode(Asn1Boolean b, Stream outRenamed);
+        void Encode(Asn1Boolean b, Stream output);
 
         /// <summary>
         ///     Encode an Asn1Numeric directly to a stream.
@@ -63,11 +63,11 @@ namespace Novell.Directory.Ldap.Asn1
         /// <param name="n">
         ///     The Asn1Numeric object to encode.
         /// </param>
-        /// <param name="outRenamed">
+        /// <param name="output">
         ///     The output stream onto which the ASN.1 object is
         ///     to be encoded.
         /// </param>
-        void Encode(Asn1Numeric n, Stream outRenamed);
+        void Encode(Asn1Numeric n, Stream output);
 
         /* Asn1 TYPE NOT YET SUPPORTED
         * Encode an Asn1Real directly to a stream.
@@ -81,11 +81,11 @@ namespace Novell.Directory.Ldap.Asn1
         /// <param name="n">
         ///     The Asn1Null object to encode.
         /// </param>
-        /// <param name="outRenamed">
+        /// <param name="output">
         ///     The output stream onto which the ASN.1 object is
         ///     to be encoded.
         /// </param>
-        void Encode(Asn1Null n, Stream outRenamed);
+        void Encode(Asn1Null n, Stream output);
 
         /* Asn1 TYPE NOT YET SUPPORTED
         * Encode an Asn1BitString directly to a stream.
@@ -99,11 +99,11 @@ namespace Novell.Directory.Ldap.Asn1
         /// <param name="os">
         ///     The Asn1OctetString object to encode.
         /// </param>
-        /// <param name="outRenamed">
+        /// <param name="output">
         ///     The output stream onto which the ASN.1 object is
         ///     to be encoded.
         /// </param>
-        void Encode(Asn1OctetString os, Stream outRenamed);
+        void Encode(Asn1OctetString os, Stream output);
 
         /* Asn1 TYPE NOT YET SUPPORTED
         * Encode an Asn1ObjectIdentifier directly to a stream.
@@ -126,11 +126,11 @@ namespace Novell.Directory.Ldap.Asn1
         /// <param name="c">
         ///     The Asn1Structured object to encode.
         /// </param>
-        /// <param name="outRenamed">
+        /// <param name="output">
         ///     The output stream onto which the ASN.1 object is
         ///     to be encoded.
         /// </param>
-        void Encode(Asn1Structured c, Stream outRenamed);
+        void Encode(Asn1Structured c, Stream output);
 
         /// <summary>
         ///     Encode an Asn1Tagged directly to a stream.
@@ -138,11 +138,11 @@ namespace Novell.Directory.Ldap.Asn1
         /// <param name="t">
         ///     The Asn1Tagged object to encode.
         /// </param>
-        /// <param name="outRenamed">
+        /// <param name="output">
         ///     The output stream onto which the ASN.1 object is
         ///     to be encoded.
         /// </param>
-        void Encode(Asn1Tagged t, Stream outRenamed);
+        void Encode(Asn1Tagged t, Stream output);
 
         /* Encoders for ASN.1 useful types
         */
@@ -156,10 +156,10 @@ namespace Novell.Directory.Ldap.Asn1
         /// <param name="id">
         ///     The Asn1Identifier object to encode.
         /// </param>
-        /// <param name="outRenamed">
+        /// <param name="output">
         ///     The output stream onto which the ASN.1 object is
         ///     to be encoded.
         /// </param>
-        void Encode(Asn1Identifier id, Stream outRenamed);
+        void Encode(Asn1Identifier id, Stream output);
     }
 }

--- a/src/Novell.Directory.Ldap.NETStandard/Asn1/Asn1Enumerated.cs
+++ b/src/Novell.Directory.Ldap.NETStandard/Asn1/Asn1Enumerated.cs
@@ -80,7 +80,7 @@ namespace Novell.Directory.Ldap.Asn1
         ///     A byte stream that contains the encoded ASN.1.
         /// </param>
         public Asn1Enumerated(IAsn1Decoder dec, Stream inRenamed, int len)
-            : base(Id, (long)dec.DecodeNumeric(inRenamed, len))
+            : base(Id, dec.DecodeNumeric(inRenamed, len))
         {
         }
 

--- a/src/Novell.Directory.Ldap.NETStandard/Asn1/Asn1Enumerated.cs
+++ b/src/Novell.Directory.Ldap.NETStandard/Asn1/Asn1Enumerated.cs
@@ -76,11 +76,11 @@ namespace Novell.Directory.Ldap.Asn1
         ///     input stream.  Sometimes a developer might want to pass
         ///     in his/her own decoder object.
         /// </param>
-        /// <param name="inRenamed">
+        /// <param name="input">
         ///     A byte stream that contains the encoded ASN.1.
         /// </param>
-        public Asn1Enumerated(IAsn1Decoder dec, Stream inRenamed, int len)
-            : base(Id, dec.DecodeNumeric(inRenamed, len))
+        public Asn1Enumerated(IAsn1Decoder dec, Stream input, int len)
+            : base(Id, dec.DecodeNumeric(input, len))
         {
         }
 
@@ -91,13 +91,13 @@ namespace Novell.Directory.Ldap.Asn1
         /// <param name="enc">
         ///     Encoder object to use when encoding self.
         /// </param>
-        /// <param name="outRenamed">
+        /// <param name="output">
         ///     The output stream onto which the encoded byte
         ///     stream is written.
         /// </param>
-        public override void Encode(IAsn1Encoder enc, Stream outRenamed)
+        public override void Encode(IAsn1Encoder enc, Stream output)
         {
-            enc.Encode(this, outRenamed);
+            enc.Encode(this, output);
         }
 
         /// <summary> Return a String representation of this Asn1Enumerated.</summary>

--- a/src/Novell.Directory.Ldap.NETStandard/Asn1/Asn1Identifier.cs
+++ b/src/Novell.Directory.Ldap.NETStandard/Asn1/Asn1Identifier.cs
@@ -115,12 +115,12 @@ namespace Novell.Directory.Ldap.Asn1
         ///     Decode an Asn1Identifier directly from an InputStream and
         ///     save the encoded length of the Asn1Identifier.
         /// </summary>
-        /// <param name="inRenamed">
+        /// <param name="input">
         ///     The input stream to decode from.
         /// </param>
-        public Asn1Identifier(Stream inRenamed)
+        public Asn1Identifier(Stream input)
         {
-            Reset(inRenamed);
+            Reset(input);
         }
 
         public Asn1Identifier()
@@ -189,13 +189,13 @@ namespace Novell.Directory.Ldap.Asn1
         ///     Decode an Asn1Identifier directly from an InputStream and
         ///     save the encoded length of the Asn1Identifier, but reuse the object.
         /// </summary>
-        /// <param name="inRenamed">
+        /// <param name="input">
         ///     The input stream to decode from.
         /// </param>
-        public void Reset(Stream inRenamed)
+        public void Reset(Stream input)
         {
             EncodedLength = 0;
-            var r = inRenamed.ReadByte();
+            var r = input.ReadByte();
             EncodedLength++;
             if (r < 0)
             {
@@ -209,7 +209,7 @@ namespace Novell.Directory.Ldap.Asn1
             // if true, its a multiple octet identifier.
             if (Tag == 0x1F)
             {
-                Tag = DecodeTagNumber(inRenamed);
+                Tag = DecodeTagNumber(input);
             }
         }
 
@@ -217,12 +217,12 @@ namespace Novell.Directory.Ldap.Asn1
         ///     In the case that we have a tag number that is greater than 30, we need
         ///     to decode a multiple octet tag number.
         /// </summary>
-        private int DecodeTagNumber(Stream inRenamed)
+        private int DecodeTagNumber(Stream input)
         {
             var n = 0;
             while (true)
             {
-                var r = inRenamed.ReadByte();
+                var r = input.ReadByte();
                 EncodedLength++;
                 if (r < 0)
                 {

--- a/src/Novell.Directory.Ldap.NETStandard/Asn1/Asn1Integer.cs
+++ b/src/Novell.Directory.Ldap.NETStandard/Asn1/Asn1Integer.cs
@@ -80,7 +80,7 @@ namespace Novell.Directory.Ldap.Asn1
         ///     A byte stream that contains the encoded ASN.1.
         /// </param>
         public Asn1Integer(IAsn1Decoder dec, Stream inRenamed, int len)
-            : base(Id, (long)dec.DecodeNumeric(inRenamed, len))
+            : base(Id, dec.DecodeNumeric(inRenamed, len))
         {
         }
 

--- a/src/Novell.Directory.Ldap.NETStandard/Asn1/Asn1Integer.cs
+++ b/src/Novell.Directory.Ldap.NETStandard/Asn1/Asn1Integer.cs
@@ -76,11 +76,11 @@ namespace Novell.Directory.Ldap.Asn1
         ///     input stream.  Sometimes a developer might want to pass
         ///     in his/her own decoder object.
         /// </param>
-        /// <param name="inRenamed">
+        /// <param name="input">
         ///     A byte stream that contains the encoded ASN.1.
         /// </param>
-        public Asn1Integer(IAsn1Decoder dec, Stream inRenamed, int len)
-            : base(Id, dec.DecodeNumeric(inRenamed, len))
+        public Asn1Integer(IAsn1Decoder dec, Stream input, int len)
+            : base(Id, dec.DecodeNumeric(input, len))
         {
         }
 
@@ -94,13 +94,13 @@ namespace Novell.Directory.Ldap.Asn1
         /// <param name="enc">
         ///     Encoder object to use when encoding self.
         /// </param>
-        /// <param name="outRenamed">
+        /// <param name="output">
         ///     The output stream onto which the encoded byte
         ///     stream is written.
         /// </param>
-        public override void Encode(IAsn1Encoder enc, Stream outRenamed)
+        public override void Encode(IAsn1Encoder enc, Stream output)
         {
-            enc.Encode(this, outRenamed);
+            enc.Encode(this, output);
         }
 
         /* Asn1Integer specific methods

--- a/src/Novell.Directory.Ldap.NETStandard/Asn1/Asn1Length.cs
+++ b/src/Novell.Directory.Ldap.NETStandard/Asn1/Asn1Length.cs
@@ -46,12 +46,12 @@ namespace Novell.Directory.Ldap.Asn1
         ///     Constructs an Asn1Length object by decoding data from an
         ///     input stream.
         /// </summary>
-        /// <param name="inRenamed">
+        /// <param name="input">
         ///     A byte stream that contains the encoded ASN.1.
         /// </param>
-        public Asn1Length(Stream inRenamed)
+        public Asn1Length(Stream input)
         {
-            Reset(inRenamed);
+            Reset(input);
         }
 
         /// <summary> Returns the length of this Asn1Length.</summary>
@@ -65,13 +65,13 @@ namespace Novell.Directory.Ldap.Asn1
         ///     input stream.
         ///     Note: this was added for optimization of Asn1.LBERdecoder.decode().
         /// </summary>
-        /// <param name="inRenamed">
+        /// <param name="input">
         ///     A byte stream that contains the encoded ASN.1.
         /// </param>
-        public void Reset(Stream inRenamed)
+        public void Reset(Stream input)
         {
             EncodedLength = 0;
-            var r = inRenamed.ReadByte();
+            var r = input.ReadByte();
             EncodedLength++;
             if (r == 0x80)
             {
@@ -86,7 +86,7 @@ namespace Novell.Directory.Ldap.Asn1
                 Length = 0;
                 for (r = r & 0x7F; r > 0; r--)
                 {
-                    var part = inRenamed.ReadByte();
+                    var part = input.ReadByte();
                     EncodedLength++;
                     if (part < 0)
                     {

--- a/src/Novell.Directory.Ldap.NETStandard/Asn1/Asn1Null.cs
+++ b/src/Novell.Directory.Ldap.NETStandard/Asn1/Asn1Null.cs
@@ -60,13 +60,13 @@ namespace Novell.Directory.Ldap.Asn1
         /// <param name="enc">
         ///     Encoder object to use when encoding self.
         /// </param>
-        /// <param name="outRenamed">
+        /// <param name="output">
         ///     The output stream onto which the encoded byte
         ///     stream is written.
         /// </param>
-        public override void Encode(IAsn1Encoder enc, Stream outRenamed)
+        public override void Encode(IAsn1Encoder enc, Stream output)
         {
-            enc.Encode(this, outRenamed);
+            enc.Encode(this, output);
         }
 
         /* Asn1Null specific methods

--- a/src/Novell.Directory.Ldap.NETStandard/Asn1/Asn1Numeric.cs
+++ b/src/Novell.Directory.Ldap.NETStandard/Asn1/Asn1Numeric.cs
@@ -32,24 +32,17 @@ namespace Novell.Directory.Ldap.Asn1
     {
         private readonly long _content;
 
-        internal Asn1Numeric(Asn1Identifier id, int valueRenamed)
+        internal Asn1Numeric(Asn1Identifier id, int content)
             : base(id)
         {
-            _content = valueRenamed;
+            _content = content;
         }
 
-        internal Asn1Numeric(Asn1Identifier id, long valueRenamed)
+        internal Asn1Numeric(Asn1Identifier id, long content)
             : base(id)
         {
-            _content = valueRenamed;
+            _content = content;
         }
-
-        /*      internal Asn1Numeric(Asn1Identifier id, System.Int64 value_Renamed):base(id)
-                {
-                    content = value_Renamed;
-                    return ;
-                }
-        */
 
         /// <summary> Returns the content of this Asn1Numeric object as an int.</summary>
         public int IntValue()

--- a/src/Novell.Directory.Ldap.NETStandard/Asn1/Asn1Object.cs
+++ b/src/Novell.Directory.Ldap.NETStandard/Asn1/Asn1Object.cs
@@ -42,11 +42,11 @@ namespace Novell.Directory.Ldap.Asn1
         ///     class to encode itself ( an Asn1Object) directly intto
         ///     a output stream.
         /// </summary>
-        /// <param name="outRenamed">
+        /// <param name="output">
         ///     The output stream onto which the encoded
         ///     Asn1Object will be placed.
         /// </param>
-        public abstract void Encode(IAsn1Encoder enc, Stream outRenamed);
+        public abstract void Encode(IAsn1Encoder enc, Stream output);
 
         /// <summary>
         ///     Returns the identifier for this Asn1Object as an Asn1Identifier.
@@ -75,23 +75,23 @@ namespace Novell.Directory.Ldap.Asn1
         ///     This method returns a byte array representing the encoded
         ///     Asn1Object.  It in turn calls the encode method that is
         ///     defined in Asn1Object but will usually be implemented
-        ///     in the child Asn1 classses.
+        ///     in the child Asn1 classes.
         /// </summary>
         public byte[] GetEncoding(IAsn1Encoder enc)
         {
-            var outRenamed = new MemoryStream();
+            var output = new MemoryStream();
             try
             {
-                Encode(enc, outRenamed);
+                Encode(enc, output);
             }
             catch (IOException e)
             {
                 // Should never happen - the current Asn1Object does not have
-                // a encode method.
+                // an encode method.
                 throw new Exception("IOException while encoding to byte array: " + e);
             }
 
-            return outRenamed.ToArray();
+            return output.ToArray();
         }
 
         /// <summary> Return a String representation of this Asn1Object.</summary>

--- a/src/Novell.Directory.Ldap.NETStandard/Asn1/Asn1OctetString.cs
+++ b/src/Novell.Directory.Ldap.NETStandard/Asn1/Asn1OctetString.cs
@@ -89,13 +89,13 @@ namespace Novell.Directory.Ldap.Asn1
         ///     input stream.  Sometimes a developer might want to pass
         ///     in his/her own decoder object.
         /// </param>
-        /// <param name="inRenamed">
+        /// <param name="input">
         ///     A byte stream that contains the encoded ASN.1.
         /// </param>
-        public Asn1OctetString(IAsn1Decoder dec, Stream inRenamed, int len)
+        public Asn1OctetString(IAsn1Decoder dec, Stream input, int len)
             : base(Id)
         {
-            _content = len > 0 ? dec.DecodeOctetString(inRenamed, len) : Array.Empty<byte>();
+            _content = len > 0 ? dec.DecodeOctetString(input, len) : Array.Empty<byte>();
         }
 
         /* Asn1Object implementation
@@ -108,13 +108,13 @@ namespace Novell.Directory.Ldap.Asn1
         /// <param name="enc">
         ///     Encoder object to use when encoding self.
         /// </param>
-        /// <param name="outRenamed">
+        /// <param name="output">
         ///     The output stream onto which the encoded byte
         ///     stream is written.
         /// </param>
-        public override void Encode(IAsn1Encoder enc, Stream outRenamed)
+        public override void Encode(IAsn1Encoder enc, Stream output)
         {
-            enc.Encode(this, outRenamed);
+            enc.Encode(this, output);
         }
 
         /*Asn1OctetString specific methods

--- a/src/Novell.Directory.Ldap.NETStandard/Asn1/Asn1OctetString.cs
+++ b/src/Novell.Directory.Ldap.NETStandard/Asn1/Asn1OctetString.cs
@@ -95,7 +95,7 @@ namespace Novell.Directory.Ldap.Asn1
         public Asn1OctetString(IAsn1Decoder dec, Stream inRenamed, int len)
             : base(Id)
         {
-            _content = len > 0 ? (byte[])dec.DecodeOctetString(inRenamed, len) : new byte[0];
+            _content = len > 0 ? dec.DecodeOctetString(inRenamed, len) : Array.Empty<byte>();
         }
 
         /* Asn1Object implementation

--- a/src/Novell.Directory.Ldap.NETStandard/Asn1/Asn1Sequence.cs
+++ b/src/Novell.Directory.Ldap.NETStandard/Asn1/Asn1Sequence.cs
@@ -92,13 +92,13 @@ namespace Novell.Directory.Ldap.Asn1
         ///     input stream.  Sometimes a developer might want to pass
         ///     in his/her own decoder object.
         /// </param>
-        /// <param name="inRenamed">
+        /// <param name="input">
         ///     A byte stream that contains the encoded ASN.1.
         /// </param>
-        public Asn1Sequence(IAsn1Decoder dec, Stream inRenamed, int len)
+        public Asn1Sequence(IAsn1Decoder dec, Stream input, int len)
             : base(Id)
         {
-            DecodeStructured(dec, inRenamed, len);
+            DecodeStructured(dec, input, len);
         }
 
         /* Asn1Sequence specific methods

--- a/src/Novell.Directory.Ldap.NETStandard/Asn1/Asn1SequenceOf.cs
+++ b/src/Novell.Directory.Ldap.NETStandard/Asn1/Asn1SequenceOf.cs
@@ -91,13 +91,13 @@ namespace Novell.Directory.Ldap.Asn1
         ///     input stream.  Sometimes a developer might want to pass
         ///     in his/her own decoder object.
         /// </param>
-        /// <param name="inRenamed">
+        /// <param name="input">
         ///     A byte stream that contains the encoded ASN.1.
         /// </param>
-        public Asn1SequenceOf(IAsn1Decoder dec, Stream inRenamed, int len)
+        public Asn1SequenceOf(IAsn1Decoder dec, Stream input, int len)
             : base(Id)
         {
-            DecodeStructured(dec, inRenamed, len);
+            DecodeStructured(dec, input, len);
         }
 
         /* Asn1SequenceOf specific methods

--- a/src/Novell.Directory.Ldap.NETStandard/Asn1/Asn1SequenceOf.cs
+++ b/src/Novell.Directory.Ldap.NETStandard/Asn1/Asn1SequenceOf.cs
@@ -78,7 +78,7 @@ namespace Novell.Directory.Ldap.Asn1
         ///     Asn1Sequence.
         /// </summary>
         public Asn1SequenceOf(Asn1Sequence sequence)
-            : base(Id, sequence.ToArray(), sequence.Size())
+            : base(Id, sequence.ToArray(), sequence.Count)
         {
         }
 

--- a/src/Novell.Directory.Ldap.NETStandard/Asn1/Asn1Set.cs
+++ b/src/Novell.Directory.Ldap.NETStandard/Asn1/Asn1Set.cs
@@ -76,13 +76,13 @@ namespace Novell.Directory.Ldap.Asn1
         ///     input stream.  Sometimes a developer might want to pass
         ///     in his/her own decoder object.
         /// </param>
-        /// <param name="inRenamed">
+        /// <param name="input">
         ///     A byte stream that contains the encoded ASN.1.
         /// </param>
-        public Asn1Set(IAsn1Decoder dec, Stream inRenamed, int len)
+        public Asn1Set(IAsn1Decoder dec, Stream input, int len)
             : base(Id)
         {
-            DecodeStructured(dec, inRenamed, len);
+            DecodeStructured(dec, input, len);
         }
 
         /* Asn1Set specific methods

--- a/src/Novell.Directory.Ldap.NETStandard/Asn1/Asn1SetOf.cs
+++ b/src/Novell.Directory.Ldap.NETStandard/Asn1/Asn1SetOf.cs
@@ -73,8 +73,8 @@ namespace Novell.Directory.Ldap.Asn1
         ///     able to construct this object when knowingly receiving an
         ///     Asn1Set.
         /// </summary>
-        public Asn1SetOf(Asn1Set setRenamed)
-            : base(Id, setRenamed.ToArray(), setRenamed.Count)
+        public Asn1SetOf(Asn1Set set)
+            : base(Id, set.ToArray(), set.Count)
         {
         }
 

--- a/src/Novell.Directory.Ldap.NETStandard/Asn1/Asn1SetOf.cs
+++ b/src/Novell.Directory.Ldap.NETStandard/Asn1/Asn1SetOf.cs
@@ -74,7 +74,7 @@ namespace Novell.Directory.Ldap.Asn1
         ///     Asn1Set.
         /// </summary>
         public Asn1SetOf(Asn1Set setRenamed)
-            : base(Id, setRenamed.ToArray(), setRenamed.Size())
+            : base(Id, setRenamed.ToArray(), setRenamed.Count)
         {
         }
 

--- a/src/Novell.Directory.Ldap.NETStandard/Asn1/Asn1Structured.cs
+++ b/src/Novell.Directory.Ldap.NETStandard/Asn1/Asn1Structured.cs
@@ -94,12 +94,10 @@ namespace Novell.Directory.Ldap.Asn1
         /// <summary> Decode an Asn1Structured type from an InputStream.</summary>
         protected internal void DecodeStructured(IAsn1Decoder dec, Stream input, int len)
         {
-            var componentLen = new int[1]; // collects length of component
-
             while (len > 0)
             {
-                Add(dec.Decode(input, componentLen));
-                len -= componentLen[0];
+                Add(dec.Decode(input, out var componentLen));
+                len -= componentLen;
             }
         }
 

--- a/src/Novell.Directory.Ldap.NETStandard/Asn1/Asn1Structured.cs
+++ b/src/Novell.Directory.Ldap.NETStandard/Asn1/Asn1Structured.cs
@@ -22,8 +22,10 @@
 *******************************************************************************/
 
 using System;
+using System.Collections;
 using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using System.Text;
 
 namespace Novell.Directory.Ldap.Asn1
@@ -32,14 +34,14 @@ namespace Novell.Directory.Ldap.Asn1
     ///     This class serves as the base type for all ASN.1
     ///     structured types.
     /// </summary>
-    public abstract class Asn1Structured : Asn1Object
+    public abstract class Asn1Structured : Asn1Object, IReadOnlyList<Asn1Object>
     {
         private Asn1Object[] _content;
 
         private int _contentIndex;
 
         /*
-        * Create a an Asn1 structured type with default size of 10
+        * Create an Asn1 structured type with default size of 10
         *
         * @param the Asn1Identifier containing the tag for this structured type
         */
@@ -119,73 +121,62 @@ namespace Novell.Directory.Ldap.Asn1
         ///     Adds a new Asn1Object to the end of this Asn1Structured
         ///     object.
         /// </summary>
-        /// <param name="valueRenamed">
+        /// <param name="value">
         ///     The Asn1Object to add to this Asn1Structured
         ///     object.
         /// </param>
-        public void Add(Asn1Object valueRenamed)
+        public void Add(Asn1Object value)
         {
             if (_contentIndex == _content.Length)
             {
                 // Array too small, need to expand it, double length
-                Array.Resize(ref _content, _contentIndex + _contentIndex);
+                var newSize = Math.Max(_contentIndex + _contentIndex, 1);
+                Array.Resize(ref _content, newSize);
             }
 
-            _content[_contentIndex++] = valueRenamed;
+            _content[_contentIndex++] = value;
         }
 
-        /// <summary>
-        ///     Replaces the Asn1Object in the specified index position of
-        ///     this Asn1Structured object.
-        /// </summary>
-        /// <param name="index">
-        ///     The index into the Asn1Structured object where
-        ///     this new ANS1Object will be placed.
-        /// </param>
-        /// <param name="valueRenamed">
-        ///     The Asn1Object to set in this Asn1Structured
-        ///     object.
-        /// </param>
-        public void set_Renamed(int index, Asn1Object valueRenamed)
+        public Asn1Object this[int index]
         {
-            if (index >= _contentIndex || index < 0)
+            get
             {
-                throw new IndexOutOfRangeException("Asn1Structured: get: index " + index + ", size " + _contentIndex);
+                if (index >= _contentIndex || index < 0)
+                {
+                    throw new ArgumentOutOfRangeException(
+                        nameof(index),
+                        index,
+                        "Asn1Structured: get: index " + index + ", size " + _contentIndex);
+                }
+
+                return _content[index];
             }
-
-            _content[index] = valueRenamed;
-        }
-
-        /// <summary>
-        ///     Gets a specific Asn1Object in this structred object.
-        /// </summary>
-        /// <param name="index">
-        ///     The index of the Asn1Object to get from
-        ///     this Asn1Structured object.
-        /// </param>
-        public Asn1Object get_Renamed(int index)
-        {
-            if (index >= _contentIndex || index < 0)
+            set
             {
-                throw new IndexOutOfRangeException("Asn1Structured: set: index " + index + ", size " + _contentIndex);
-            }
+                if (index >= _contentIndex || index < 0)
+                {
+                    throw new ArgumentOutOfRangeException(
+                        nameof(index),
+                        index,
+                        "Asn1Structured: set: index " + index + ", size " + _contentIndex);
+                }
 
-            return _content[index];
+                _content[index] = value;
+            }
         }
 
         /// <summary>
         ///     Returns the number of Asn1Obejcts that have been encoded
         ///     into this Asn1Structured class.
         /// </summary>
-        public int Size()
-        {
-            return _contentIndex;
-        }
+        public int Count => _contentIndex;
+
+        IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
 
         /// <summary>
-        ///     Gets an enumerable of Asn1Objects in this structred object.
+        ///     Gets an enumerator of Asn1Objects in this structred object.
         /// </summary>
-        public IEnumerable<Asn1Object> RenamedEnumerable => new ArraySegment<Asn1Object>(_content, 0, _contentIndex);
+        public IEnumerator<Asn1Object> GetEnumerator() => new ArraySegment<Asn1Object>(_content, 0, _contentIndex).AsEnumerable().GetEnumerator();
 
         /// <summary>
         ///     Creates a String representation of this Asn1Structured.

--- a/src/Novell.Directory.Ldap.NETStandard/Asn1/Asn1Structured.cs
+++ b/src/Novell.Directory.Ldap.NETStandard/Asn1/Asn1Structured.cs
@@ -86,19 +86,19 @@ namespace Novell.Directory.Ldap.Asn1
         ///     Encodes the contents of this Asn1Structured directly to an output
         ///     stream.
         /// </summary>
-        public override void Encode(IAsn1Encoder enc, Stream outRenamed)
+        public override void Encode(IAsn1Encoder enc, Stream output)
         {
-            enc.Encode(this, outRenamed);
+            enc.Encode(this, output);
         }
 
         /// <summary> Decode an Asn1Structured type from an InputStream.</summary>
-        protected internal void DecodeStructured(IAsn1Decoder dec, Stream inRenamed, int len)
+        protected internal void DecodeStructured(IAsn1Decoder dec, Stream input, int len)
         {
             var componentLen = new int[1]; // collects length of component
 
             while (len > 0)
             {
-                Add(dec.Decode(inRenamed, componentLen));
+                Add(dec.Decode(input, componentLen));
                 len -= componentLen[0];
             }
         }

--- a/src/Novell.Directory.Ldap.NETStandard/Asn1/Asn1Tagged.cs
+++ b/src/Novell.Directory.Ldap.NETStandard/Asn1/Asn1Tagged.cs
@@ -48,19 +48,19 @@ namespace Novell.Directory.Ldap.Asn1
         ///     AN1Identifier and the Asn1Object.
         ///     The explicit flag defaults to true as per the spec.
         /// </summary>
-        public Asn1Tagged(Asn1Identifier identifier, Asn1Object objectRenamed)
-            : this(identifier, objectRenamed, true)
+        public Asn1Tagged(Asn1Identifier identifier, Asn1Object asn1Object)
+            : this(identifier, asn1Object, true)
         {
         }
 
         /// <summary> Constructs an Asn1Tagged object.</summary>
-        public Asn1Tagged(Asn1Identifier identifier, Asn1Object objectRenamed, bool explicitRenamed)
+        public Asn1Tagged(Asn1Identifier identifier, Asn1Object asn1Object, bool explicitTagging)
             : base(identifier)
         {
-            _content = objectRenamed;
-            Explicit = explicitRenamed;
+            _content = asn1Object;
+            Explicit = explicitTagging;
 
-            if (!explicitRenamed && _content != null)
+            if (!explicitTagging && _content != null)
             {
                 // replace object's id with new tag.
                 _content.SetIdentifier(identifier);
@@ -76,17 +76,17 @@ namespace Novell.Directory.Ldap.Asn1
         ///     input stream.  Sometimes a developer might want to pass
         ///     in his/her own decoder object.
         /// </param>
-        /// <param name="inRenamed">
+        /// <param name="input">
         ///     A byte stream that contains the encoded ASN.1.
         /// </param>
-        public Asn1Tagged(IAsn1Decoder dec, Stream inRenamed, int len, Asn1Identifier identifier)
+        public Asn1Tagged(IAsn1Decoder dec, Stream input, int len, Asn1Identifier identifier)
             : base(identifier)
         {
             // If we are decoding an implicit tag, there is no way to know at this
             // low level what the base type really is. We can place the content
             // into an Asn1OctetString type and pass it back to the application who
             // will be able to create the appropriate ASN.1 type for this tag.
-            _content = new Asn1OctetString(dec, inRenamed, len);
+            _content = new Asn1OctetString(dec, input, len);
         }
 
         /// <summary> Sets the Asn1Object tagged value.</summary>
@@ -120,13 +120,13 @@ namespace Novell.Directory.Ldap.Asn1
         /// <param name="enc">
         ///     Encoder object to use when encoding self.
         /// </param>
-        /// <param name="outRenamed">
+        /// <param name="output">
         ///     The output stream onto which the encoded byte
         ///     stream is written.
         /// </param>
-        public override void Encode(IAsn1Encoder enc, Stream outRenamed)
+        public override void Encode(IAsn1Encoder enc, Stream output)
         {
-            enc.Encode(this, outRenamed);
+            enc.Encode(this, output);
         }
 
         /* Asn1Tagged specific methods

--- a/src/Novell.Directory.Ldap.NETStandard/Asn1/LBERDecoder.cs
+++ b/src/Novell.Directory.Ldap.NETStandard/Asn1/LBERDecoder.cs
@@ -83,8 +83,7 @@ namespace Novell.Directory.Ldap.Asn1
         /// <summary> Decode an LBER encoded value into an Asn1Type from an InputStream.</summary>
         public Asn1Object Decode(Stream input)
         {
-            var len = new int[1];
-            return Decode(input, len);
+            return Decode(input, out _);
         }
 
         /// <summary>
@@ -94,13 +93,13 @@ namespace Novell.Directory.Ldap.Asn1
         ///     in the parameter len. This information is helpful when decoding
         ///     structured types.
         /// </summary>
-        public Asn1Object Decode(Stream input, int[] len)
+        public Asn1Object Decode(Stream input, out int len)
         {
             _asn1Id.Reset(input);
             _asn1Len.Reset(input);
 
             var length = _asn1Len.Length;
-            len[0] = _asn1Id.EncodedLength + _asn1Len.EncodedLength + length;
+            len = _asn1Id.EncodedLength + _asn1Len.EncodedLength + length;
 
             if (_asn1Id.IsUniversal)
             {

--- a/src/Novell.Directory.Ldap.NETStandard/Asn1/LBERDecoder.cs
+++ b/src/Novell.Directory.Ldap.NETStandard/Asn1/LBERDecoder.cs
@@ -65,28 +65,26 @@ namespace Novell.Directory.Ldap.Asn1
         */
 
         /// <summary> Decode an LBER encoded value into an Asn1Type from a byte array.</summary>
-        public Asn1Object Decode(byte[] valueRenamed)
+        public Asn1Object Decode(byte[] value)
         {
-            Asn1Object asn1 = null;
-
-            var inRenamed = new MemoryStream(valueRenamed);
+            var input = new MemoryStream(value);
             try
             {
-                asn1 = Decode(inRenamed);
+                return Decode(input);
             }
             catch (IOException ioe)
             {
                 Logger.Log.LogWarning("Exception swallowed", ioe);
             }
 
-            return asn1;
+            return null;
         }
 
         /// <summary> Decode an LBER encoded value into an Asn1Type from an InputStream.</summary>
-        public Asn1Object Decode(Stream inRenamed)
+        public Asn1Object Decode(Stream input)
         {
             var len = new int[1];
-            return Decode(inRenamed, len);
+            return Decode(input, len);
         }
 
         /// <summary>
@@ -96,10 +94,10 @@ namespace Novell.Directory.Ldap.Asn1
         ///     in the parameter len. This information is helpful when decoding
         ///     structured types.
         /// </summary>
-        public Asn1Object Decode(Stream inRenamed, int[] len)
+        public Asn1Object Decode(Stream input, int[] len)
         {
-            _asn1Id.Reset(inRenamed);
-            _asn1Len.Reset(inRenamed);
+            _asn1Id.Reset(input);
+            _asn1Len.Reset(input);
 
             var length = _asn1Len.Length;
             len[0] = _asn1Id.EncodedLength + _asn1Len.EncodedLength + length;
@@ -109,22 +107,22 @@ namespace Novell.Directory.Ldap.Asn1
                 switch (_asn1Id.Tag)
                 {
                     case Asn1Sequence.Tag:
-                        return new Asn1Sequence(this, inRenamed, length);
+                        return new Asn1Sequence(this, input, length);
 
                     case Asn1Set.Tag:
-                        return new Asn1Set(this, inRenamed, length);
+                        return new Asn1Set(this, input, length);
 
                     case Asn1Boolean.Tag:
-                        return new Asn1Boolean(this, inRenamed, length);
+                        return new Asn1Boolean(this, input, length);
 
                     case Asn1Integer.Tag:
-                        return new Asn1Integer(this, inRenamed, length);
+                        return new Asn1Integer(this, input, length);
 
                     case Asn1OctetString.Tag:
-                        return new Asn1OctetString(this, inRenamed, length);
+                        return new Asn1OctetString(this, input, length);
 
                     case Asn1Enumerated.Tag:
-                        return new Asn1Enumerated(this, inRenamed, length);
+                        return new Asn1Enumerated(this, input, length);
 
                     case Asn1Null.Tag:
                         return new Asn1Null(); // has no content to decode.
@@ -159,18 +157,18 @@ namespace Novell.Directory.Ldap.Asn1
             }
 
             // APPLICATION or CONTEXT-SPECIFIC tag
-            return new Asn1Tagged(this, inRenamed, length, (Asn1Identifier)_asn1Id.Clone());
+            return new Asn1Tagged(this, input, length, (Asn1Identifier)_asn1Id.Clone());
         }
 
         /* Decoders for ASN.1 simple type Contents
         */
 
         /// <summary> Decode a boolean directly from a stream.</summary>
-        public bool DecodeBoolean(Stream inRenamed, int len)
+        public bool DecodeBoolean(Stream input, int len)
         {
             var lber = new byte[len];
 
-            var i = ReadInput(inRenamed, lber, 0, lber.Length);
+            var i = ReadInput(input, lber, 0, lber.Length);
 
             if (i != len)
             {
@@ -184,10 +182,10 @@ namespace Novell.Directory.Ldap.Asn1
         ///     Decode a Numeric type directly from a stream. Decodes INTEGER
         ///     and ENUMERATED types.
         /// </summary>
-        public long DecodeNumeric(Stream inRenamed, int len)
+        public long DecodeNumeric(Stream input, int len)
         {
             long l = 0;
-            var r = (long)inRenamed.ReadByte();
+            var r = (long)input.ReadByte();
 
             if (r < 0)
             {
@@ -204,7 +202,7 @@ namespace Novell.Directory.Ldap.Asn1
 
             for (var i = 1; i < len; i++)
             {
-                r = inRenamed.ReadByte();
+                r = input.ReadByte();
                 if (r < 0)
                 {
                     throw new EndOfStreamException("LBER: NUMERIC: decode error: EOF");
@@ -217,7 +215,7 @@ namespace Novell.Directory.Ldap.Asn1
         }
 
         /// <summary> Decode an OctetString directly from a stream.</summary>
-        public byte[] DecodeOctetString(Stream inRenamed, int len)
+        public byte[] DecodeOctetString(Stream input, int len)
         {
             var octets = new byte[len];
             var totalLen = 0;
@@ -225,7 +223,7 @@ namespace Novell.Directory.Ldap.Asn1
             while (totalLen < len)
             {
                 // Make sure we have read all the data
-                var inLen = ReadInput(inRenamed, octets, totalLen, len - totalLen);
+                var inLen = ReadInput(input, octets, totalLen, len - totalLen);
                 totalLen += inLen;
             }
 
@@ -233,13 +231,13 @@ namespace Novell.Directory.Ldap.Asn1
         }
 
         /// <summary> Decode a CharacterString directly from a stream.</summary>
-        public string DecodeCharacterString(Stream inRenamed, int len)
+        public string DecodeCharacterString(Stream input, int len)
         {
             var octets = new byte[len];
 
             for (var i = 0; i < len; i++)
             {
-                var ret = inRenamed.ReadByte(); // blocks
+                var ret = input.ReadByte(); // blocks
                 if (ret == -1)
                 {
                     throw new EndOfStreamException("LBER: CHARACTER STRING: decode error: EOF");

--- a/src/Novell.Directory.Ldap.NETStandard/Connection.cs
+++ b/src/Novell.Directory.Ldap.NETStandard/Connection.cs
@@ -858,7 +858,7 @@ namespace Novell.Directory.Ldap
             try
             {
                 // Now send unbind if socket not closed
-                if (BindProperties != null && _outStream != null && _outStream.CanWrite && !BindProperties.Anonymous)
+                if (BindProperties is { Anonymous: false } && _outStream is { CanWrite: true })
                 {
                     try
                     {

--- a/src/Novell.Directory.Ldap.NETStandard/Controls/LdapEntryChangeControl.cs
+++ b/src/Novell.Directory.Ldap.NETStandard/Controls/LdapEntryChangeControl.cs
@@ -59,11 +59,11 @@ namespace Novell.Directory.Ldap.Controls
         ///     the control is not supported. False if
         ///     the operation can be processed without the control.
         /// </param>
-        /// <param name="valueRenamed">
+        /// <param name="value">
         ///     The control-specific data.
         /// </param>
-        public LdapEntryChangeControl(string oid, bool critical, byte[] valueRenamed)
-            : base(oid, critical, valueRenamed)
+        public LdapEntryChangeControl(string oid, bool critical, byte[] value)
+            : base(oid, critical, value)
         {
             // Create a decoder objet
             var decoder = new LberDecoder();
@@ -73,7 +73,7 @@ namespace Novell.Directory.Ldap.Controls
             }
 
             // We should get a sequence initially
-            var asnObj = decoder.Decode(valueRenamed);
+            var asnObj = decoder.Decode(value);
 
             if (asnObj is not Asn1Sequence sequence)
             {

--- a/src/Novell.Directory.Ldap.NETStandard/Controls/LdapEntryChangeControl.cs
+++ b/src/Novell.Directory.Ldap.NETStandard/Controls/LdapEntryChangeControl.cs
@@ -75,34 +75,32 @@ namespace Novell.Directory.Ldap.Controls
             // We should get a sequence initially
             var asnObj = decoder.Decode(valueRenamed);
 
-            if (asnObj == null || !(asnObj is Asn1Sequence))
+            if (asnObj is not Asn1Sequence sequence)
             {
                 throw new IOException("Decoding error.");
             }
-
-            var sequence = (Asn1Sequence)asnObj;
 
             // The first element in the sequence should be an enumerated type
-            var asn1Obj = sequence.get_Renamed(0);
-            if (asn1Obj == null || !(asn1Obj is Asn1Enumerated))
+            var asn1Obj = sequence[0];
+            if (asn1Obj is not Asn1Enumerated enumerated)
             {
                 throw new IOException("Decoding error.");
             }
 
-            ChangeType = ((Asn1Enumerated)asn1Obj).IntValue();
+            ChangeType = enumerated.IntValue();
 
             // check for optional elements
             // 8 means modifyDN
-            if (sequence.Size() > 1 && ChangeType == 8)
+            if (sequence.Count > 1 && ChangeType == 8)
             {
                 // get the previous DN - it is encoded as an octet string
-                asn1Obj = sequence.get_Renamed(1);
-                if (asn1Obj == null || !(asn1Obj is Asn1OctetString))
+                asn1Obj = sequence[1];
+                if (asn1Obj is not Asn1OctetString octetString)
                 {
                     throw new IOException("Decoding error get previous DN");
                 }
 
-                PreviousDn = ((Asn1OctetString)asn1Obj).StringValue();
+                PreviousDn = octetString.StringValue();
             }
             else
             {
@@ -110,15 +108,15 @@ namespace Novell.Directory.Ldap.Controls
             }
 
             // check for change number
-            if (sequence.Size() == 3)
+            if (sequence.Count == 3)
             {
-                asn1Obj = sequence.get_Renamed(2);
-                if (asn1Obj == null || !(asn1Obj is Asn1Integer))
+                asn1Obj = sequence[2];
+                if (asn1Obj is not Asn1Integer integer)
                 {
                     throw new IOException("Decoding error getting change number");
                 }
 
-                ChangeNumber = ((Asn1Integer)asn1Obj).IntValue();
+                ChangeNumber = integer.IntValue();
                 HasChangeNumber = true;
             }
             else

--- a/src/Novell.Directory.Ldap.NETStandard/Controls/LdapPersistSearchControl.cs
+++ b/src/Novell.Directory.Ldap.NETStandard/Controls/LdapPersistSearchControl.cs
@@ -151,11 +151,12 @@ namespace Novell.Directory.Ldap.Controls
             _mChangesOnly = changesOnly;
             _mReturnControls = returnControls;
 
-            _mSequence = new Asn1Sequence(SequenceSize);
-
-            _mSequence.Add(new Asn1Integer(_mChangeTypes));
-            _mSequence.Add(new Asn1Boolean(_mChangesOnly));
-            _mSequence.Add(new Asn1Boolean(_mReturnControls));
+            _mSequence = new Asn1Sequence(SequenceSize)
+            {
+                new Asn1Integer(_mChangeTypes),
+                new Asn1Boolean(_mChangesOnly),
+                new Asn1Boolean(_mReturnControls),
+            };
 
             SetValue();
         }
@@ -182,7 +183,7 @@ namespace Novell.Directory.Ldap.Controls
             set
             {
                 _mChangeTypes = value;
-                _mSequence.set_Renamed(ChangetypesIndex, new Asn1Integer(_mChangeTypes));
+                _mSequence[ChangetypesIndex] = new Asn1Integer(_mChangeTypes);
                 SetValue();
             }
         }
@@ -198,7 +199,7 @@ namespace Novell.Directory.Ldap.Controls
             set
             {
                 _mReturnControls = value;
-                _mSequence.set_Renamed(ReturncontrolsIndex, new Asn1Boolean(_mReturnControls));
+                _mSequence[ReturncontrolsIndex] = new Asn1Boolean(_mReturnControls);
                 SetValue();
             }
         }
@@ -214,7 +215,7 @@ namespace Novell.Directory.Ldap.Controls
             set
             {
                 _mChangesOnly = value;
-                _mSequence.set_Renamed(ChangesonlyIndex, new Asn1Boolean(_mChangesOnly));
+                _mSequence[ChangesonlyIndex] = new Asn1Boolean(_mChangesOnly);
                 SetValue();
             }
         }
@@ -223,15 +224,19 @@ namespace Novell.Directory.Ldap.Controls
         {
             var data = _mSequence.GetEncoding(SEncoder);
 
+            if (data.Length < 1)
+            {
+                return string.Empty;
+            }
+
             var buf = new StringBuilder(data.Length);
 
-            for (var i = 0; i < data.Length; i++)
+            buf.Append(data[0]);
+
+            for (var i = 1; i < data.Length; i++)
             {
-                buf.Append(data[i].ToString());
-                if (i < data.Length - 1)
-                {
-                    buf.Append(",");
-                }
+                buf.Append(',');
+                buf.Append(data[i]);
             }
 
             return buf.ToString();

--- a/src/Novell.Directory.Ldap.NETStandard/Controls/LdapSortControl.cs
+++ b/src/Novell.Directory.Ldap.NETStandard/Controls/LdapSortControl.cs
@@ -101,9 +101,10 @@ namespace Novell.Directory.Ldap.Controls
 
             for (var i = 0; i < keys.Length; i++)
             {
-                var key = new Asn1Sequence();
-
-                key.Add(new Asn1OctetString(keys[i].Key));
+                var key = new Asn1Sequence
+                {
+                    new Asn1OctetString(keys[i].Key),
+                };
 
                 if (keys[i].MatchRule != null)
                 {

--- a/src/Novell.Directory.Ldap.NETStandard/Controls/LdapSortResponse.cs
+++ b/src/Novell.Directory.Ldap.NETStandard/Controls/LdapSortResponse.cs
@@ -90,24 +90,24 @@ namespace Novell.Directory.Ldap.Controls
             // We should get back an enumerated type
             var asnObj = decoder.Decode(values);
 
-            if (asnObj == null || !(asnObj is Asn1Sequence))
+            if (asnObj is not Asn1Sequence sequence)
             {
                 throw new IOException("Decoding error");
             }
 
-            var asn1Enum = ((Asn1Sequence)asnObj).get_Renamed(0);
-            if (asn1Enum != null && asn1Enum is Asn1Enumerated)
+            var asn1Enum = sequence[0];
+            if (asn1Enum is Asn1Enumerated enumerated)
             {
-                ResultCode = ((Asn1Enumerated)asn1Enum).IntValue();
+                ResultCode = enumerated.IntValue();
             }
 
             // Second element is the attributeType
-            if (((Asn1Sequence)asnObj).Size() > 1)
+            if (sequence.Count > 1)
             {
-                var asn1String = ((Asn1Sequence)asnObj).get_Renamed(1);
-                if (asn1String != null && asn1String is Asn1OctetString)
+                var asn1String = sequence[1];
+                if (asn1String is Asn1OctetString octetString)
                 {
-                    FailedAttribute = ((Asn1OctetString)asn1String).StringValue();
+                    FailedAttribute = octetString.StringValue();
                 }
             }
         }

--- a/src/Novell.Directory.Ldap.NETStandard/Controls/LdapVirtualListControl.cs
+++ b/src/Novell.Directory.Ldap.NETStandard/Controls/LdapVirtualListControl.cs
@@ -329,12 +329,12 @@ namespace Novell.Directory.Ldap.Controls
 
                 /* Is there a context field that is already in the ber
                 */
-                if (_mVlvRequest.Size() == 4)
+                if (_mVlvRequest.Count == 4)
                 {
                     /* If YES then replace it */
-                    _mVlvRequest.set_Renamed(contextidindex, new Asn1OctetString(_mContext));
+                    _mVlvRequest[contextidindex] = new Asn1OctetString(_mContext);
                 }
-                else if (_mVlvRequest.Size() == 3)
+                else if (_mVlvRequest.Count == 3)
                 {
                     /* If no then add a new one */
                     _mVlvRequest.Add(new Asn1OctetString(_mContext));
@@ -355,21 +355,21 @@ namespace Novell.Directory.Ldap.Controls
         private void BuildTypedVlvRequest()
         {
             /* Create a new Asn1Sequence object */
-            _mVlvRequest = new Asn1Sequence(4);
-
-            /* Add the beforeCount and afterCount fields to the sequence */
-            _mVlvRequest.Add(new Asn1Integer(_mBeforeCount));
-            _mVlvRequest.Add(new Asn1Integer(_mAfterCount));
-
-            /* The next field is dependent on the type of indexing being used.
-            * A "typed" VLV request uses a ASN.1 OCTET STRING to index to the
-            * correct object in the list.  Encode the ASN.1 CHOICE corresponding
-            * to this option (as indicated by the greaterthanOrEqual field)
-            * in the ASN.1.
-            */
-            _mVlvRequest.Add(new Asn1Tagged(
-                new Asn1Identifier(Asn1Identifier.Context, false, Greaterthanorequal),
-                new Asn1OctetString(_mJumpTo), false));
+            _mVlvRequest = new Asn1Sequence(4)
+            {
+                /* Add the beforeCount and afterCount fields to the sequence */
+                new Asn1Integer(_mBeforeCount),
+                new Asn1Integer(_mAfterCount),
+                /* The next field is dependent on the type of indexing being used.
+                * A "typed" VLV request uses a ASN.1 OCTET STRING to index to the
+                * correct object in the list.  Encode the ASN.1 CHOICE corresponding
+                * to this option (as indicated by the greaterthanOrEqual field)
+                * in the ASN.1.
+                */
+                new Asn1Tagged(
+                    new Asn1Identifier(Asn1Identifier.Context, false, Greaterthanorequal),
+                    new Asn1OctetString(_mJumpTo), false),
+            };
 
             /* Add the optional context string if one is available.
             */
@@ -386,20 +386,23 @@ namespace Novell.Directory.Ldap.Controls
         private void BuildIndexedVlvRequest()
         {
             /* Create a new Asn1Sequence object */
-            _mVlvRequest = new Asn1Sequence(4);
-
-            /* Add the beforeCount and afterCount fields to the sequence */
-            _mVlvRequest.Add(new Asn1Integer(_mBeforeCount));
-            _mVlvRequest.Add(new Asn1Integer(_mAfterCount));
+            _mVlvRequest = new Asn1Sequence(4)
+            {
+                /* Add the beforeCount and afterCount fields to the sequence */
+                new Asn1Integer(_mBeforeCount),
+                new Asn1Integer(_mAfterCount),
+            };
 
             /* The next field is dependent on the type of indexing being used.
             * An "indexed" VLV request uses a ASN.1 SEQUENCE to index to the
             * correct object in the list.  Encode the ASN.1 CHOICE corresponding
             * to this option (as indicated by the byoffset fieldin the ASN.1.
             */
-            var byoffset = new Asn1Sequence(2);
-            byoffset.Add(new Asn1Integer(_mStartIndex));
-            byoffset.Add(new Asn1Integer(_mContentCount));
+            var byoffset = new Asn1Sequence(2)
+            {
+                new Asn1Integer(_mStartIndex),
+                new Asn1Integer(_mContentCount),
+            };
 
             /* Add the ASN.1 sequence to the encoded data
             */

--- a/src/Novell.Directory.Ldap.NETStandard/Controls/LdapVirtualListResponse.cs
+++ b/src/Novell.Directory.Ldap.NETStandard/Controls/LdapVirtualListResponse.cs
@@ -95,7 +95,7 @@ namespace Novell.Directory.Ldap.Controls
 
             /* We should get back an ASN.1 Sequence object */
             var asnObj = decoder.Decode(values);
-            if (asnObj == null || !(asnObj is Asn1Sequence))
+            if (asnObj is not Asn1Sequence sequence)
             {
                 throw new IOException("Decoding error");
             }
@@ -105,10 +105,10 @@ namespace Novell.Directory.Ldap.Controls
             /* Get the 1st element which should be an integer containing the
             * targetPosition (firstPosition)
             */
-            var asn1FirstPosition = ((Asn1Sequence)asnObj).get_Renamed(0);
-            if (asn1FirstPosition != null && asn1FirstPosition is Asn1Integer)
+            var asn1FirstPosition = sequence[0];
+            if (asn1FirstPosition is Asn1Integer integer)
             {
-                FirstPosition = ((Asn1Integer)asn1FirstPosition).IntValue();
+                FirstPosition = integer.IntValue();
             }
             else
             {
@@ -118,10 +118,10 @@ namespace Novell.Directory.Ldap.Controls
             /* Get the 2nd element which should be an integer containing the
             * current estimate of the contentCount
             */
-            var asn1ContentCount = ((Asn1Sequence)asnObj).get_Renamed(1);
-            if (asn1ContentCount != null && asn1ContentCount is Asn1Integer)
+            var asn1ContentCount = sequence[1];
+            if (asn1ContentCount is Asn1Integer asn1Integer)
             {
-                ContentCount = ((Asn1Integer)asn1ContentCount).IntValue();
+                ContentCount = asn1Integer.IntValue();
             }
             else
             {
@@ -129,10 +129,10 @@ namespace Novell.Directory.Ldap.Controls
             }
 
             /* The 3rd element is an enum containing the errorcode */
-            var asn1Enum = ((Asn1Sequence)asnObj).get_Renamed(2);
-            if (asn1Enum != null && asn1Enum is Asn1Enumerated)
+            var asn1Enum = sequence[2];
+            if (asn1Enum is Asn1Enumerated enumerated)
             {
-                ResultCode = ((Asn1Enumerated)asn1Enum).IntValue();
+                ResultCode = enumerated.IntValue();
             }
             else
             {
@@ -142,12 +142,12 @@ namespace Novell.Directory.Ldap.Controls
             /* Optional 4th element could be the context string that the server
             * wants the client to send back with each subsequent VLV request
             */
-            if (((Asn1Sequence)asnObj).Size() > 3)
+            if (sequence.Count > 3)
             {
-                var asn1String = ((Asn1Sequence)asnObj).get_Renamed(3);
-                if (asn1String != null && asn1String is Asn1OctetString)
+                var asn1String = sequence[3];
+                if (asn1String is Asn1OctetString octetString)
                 {
-                    Context = ((Asn1OctetString)asn1String).StringValue();
+                    Context = octetString.StringValue();
                 }
             }
         }

--- a/src/Novell.Directory.Ldap.NETStandard/Controls/SimplePagedResultsControl.cs
+++ b/src/Novell.Directory.Ldap.NETStandard/Controls/SimplePagedResultsControl.cs
@@ -59,12 +59,12 @@ namespace Novell.Directory.Ldap.Controls
             }
 
             var asn1Object = lberDecoder.Decode(values);
-            if (!(asn1Object is Asn1Sequence))
+            if (asn1Object is not Asn1Sequence sequence)
             {
                 throw new InvalidCastException(DecodedNotSequence);
             }
 
-            var size = ((Asn1Structured)asn1Object).get_Renamed(0);
+            var size = sequence[0];
             if (!(size is Asn1Integer integerSize))
             {
                 throw new InvalidOperationException(DecodedNotInteger);
@@ -72,7 +72,7 @@ namespace Novell.Directory.Ldap.Controls
 
             Size = integerSize.IntValue();
 
-            var cookie = ((Asn1Structured)asn1Object).get_Renamed(1);
+            var cookie = sequence[1];
             if (!(cookie is Asn1OctetString octetCookie))
             {
                 throw new InvalidOperationException(DecodedNotOctetString);
@@ -114,9 +114,11 @@ namespace Novell.Directory.Ldap.Controls
 
         private void BuildTypedPagedRequest()
         {
-            _request = new Asn1Sequence(2);
-            _request.Add(new Asn1Integer(Size));
-            _request.Add(new Asn1OctetString(Cookie));
+            _request = new Asn1Sequence(2)
+            {
+                new Asn1Integer(Size),
+                new Asn1OctetString(Cookie),
+            };
         }
     }
 }

--- a/src/Novell.Directory.Ldap.NETStandard/LdapAddRequest.cs
+++ b/src/Novell.Directory.Ldap.NETStandard/LdapAddRequest.cs
@@ -78,11 +78,10 @@ namespace Novell.Directory.Ldap
                     var attr = new LdapAttribute(((Asn1OctetString)seq[0]).StringValue());
 
                     // Add the values to the attribute
-                    var setRenamed = (Asn1SetOf)seq[1];
-                    object[] setArray = setRenamed.ToArray();
-                    for (var j = 0; j < setArray.Length; j++)
+                    var set = (Asn1SetOf)seq[1];
+                    foreach (Asn1OctetString octetString in set)
                     {
-                        attr.AddValue(((Asn1OctetString)setArray[j]).ByteValue());
+                        attr.AddValue(octetString.ByteValue());
                     }
 
                     attrs.Add(attr);

--- a/src/Novell.Directory.Ldap.NETStandard/LdapAddRequest.cs
+++ b/src/Novell.Directory.Ldap.NETStandard/LdapAddRequest.cs
@@ -75,10 +75,10 @@ namespace Novell.Directory.Ldap
                 for (var i = 0; i < seqArray.Length; i++)
                 {
                     var seq = (RfcAttributeTypeAndValues)seqArray[i];
-                    var attr = new LdapAttribute(((Asn1OctetString)seq.get_Renamed(0)).StringValue());
+                    var attr = new LdapAttribute(((Asn1OctetString)seq[0]).StringValue());
 
                     // Add the values to the attribute
-                    var setRenamed = (Asn1SetOf)seq.get_Renamed(1);
+                    var setRenamed = (Asn1SetOf)seq[1];
                     object[] setArray = setRenamed.ToArray();
                     for (var j = 0; j < setArray.Length; j++)
                     {

--- a/src/Novell.Directory.Ldap.NETStandard/LdapCompareAttrNames.cs
+++ b/src/Novell.Directory.Ldap.NETStandard/LdapCompareAttrNames.cs
@@ -249,12 +249,10 @@ namespace Novell.Directory.Ldap
         /// </returns>
         public override bool Equals(object comparator)
         {
-            if (!(comparator is LdapCompareAttrNames))
+            if (comparator is not LdapCompareAttrNames comp)
             {
                 return false;
             }
-
-            var comp = (LdapCompareAttrNames)comparator;
 
             // Test to see if the attribute to compare are the same length
             if (comp._sortByNames.Length != _sortByNames.Length || comp._sortAscending.Length != _sortAscending.Length)

--- a/src/Novell.Directory.Ldap.NETStandard/LdapCompareRequest.cs
+++ b/src/Novell.Directory.Ldap.NETStandard/LdapCompareRequest.cs
@@ -50,21 +50,21 @@ namespace Novell.Directory.Ldap
         /// <param name="name">
         ///     The name of the attribute to compare.
         /// </param>
-        /// <param name="valueRenamed">
+        /// <param name="value">
         ///     The value of the attribute to compare.
         /// </param>
         /// <param name="cont">
         ///     Any controls that apply to the compare request,
         ///     or null if none.
         /// </param>
-        public LdapCompareRequest(string dn, string name, byte[] valueRenamed, LdapControl[] cont)
+        public LdapCompareRequest(string dn, string name, byte[] value, LdapControl[] cont)
             : base(
                 CompareRequest,
                 new RfcCompareRequest(
                     new RfcLdapDn(dn),
                     new RfcAttributeValueAssertion(
                         new RfcAttributeDescription(name),
-                        new RfcAssertionValue(valueRenamed))), cont)
+                        new RfcAssertionValue(value))), cont)
         {
         }
 

--- a/src/Novell.Directory.Ldap.NETStandard/LdapConnection.Sasl.cs
+++ b/src/Novell.Directory.Ldap.NETStandard/LdapConnection.Sasl.cs
@@ -158,7 +158,7 @@ namespace Novell.Directory.Ldap
                 throw new LdapException("Bind failure, no response received.");
             }
 
-            var bindResponse = (RfcBindResponse)ldapResponse.Asn1Object.get_Renamed(1);
+            var bindResponse = (RfcBindResponse)ldapResponse.Asn1Object[1];
             lock (_responseCtlSemaphore)
             {
                 _responseCtls = ldapResponse.Controls;

--- a/src/Novell.Directory.Ldap.NETStandard/LdapConnection.cs
+++ b/src/Novell.Directory.Ldap.NETStandard/LdapConnection.cs
@@ -2670,8 +2670,8 @@ namespace Novell.Directory.Ldap
                     var rex = new LdapReferralException(ExceptionMessages.ReferralSend, LdapException.ConnectError,
                         null, ex);
                     rex.SetReferrals(initialReferrals);
-                    var refRenamed = rconn.Connection.ActiveReferral;
-                    rex.FailedReferral = refRenamed.ReferralUrl.ToString();
+                    var referral = rconn.Connection.ActiveReferral;
+                    rex.FailedReferral = referral.ReferralUrl.ToString();
                     throw rex;
                 }
 

--- a/src/Novell.Directory.Ldap.NETStandard/LdapConnection.cs
+++ b/src/Novell.Directory.Ldap.NETStandard/LdapConnection.cs
@@ -28,6 +28,7 @@ using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Net.Security;
+using System.Runtime.ExceptionServices;
 using System.Security.Cryptography.X509Certificates;
 using System.Threading;
 using System.Threading.Tasks;
@@ -2394,10 +2395,10 @@ namespace Novell.Directory.Ldap
                         };
                         var url = new LdapUrl(referrals[i]);
                         await rconn.ConnectAsync(url.Host, url.Port, ct).ConfigureAwait(false);
-                        if (rh is ILdapAuthHandler)
+                        if (rh is ILdapAuthHandler handler)
                         {
                             // Get application supplied dn and pw
-                            var ap = ((ILdapAuthHandler)rh).GetAuthProvider(url.Host, url.Port);
+                            var ap = handler.GetAuthProvider(url.Host, url.Port);
                             dn = ap.Dn;
                             pw = ap.Password;
                         }
@@ -2477,14 +2478,15 @@ namespace Novell.Directory.Ldap
             {
                 // Could not connect to any server, throw an exception
                 LdapException ldapex;
-                if (ex is LdapReferralException)
+                if (ex is LdapReferralException exception)
                 {
-                    throw (LdapReferralException)ex;
+                    ExceptionDispatchInfo.Capture(exception).Throw();
+                    throw exception;
                 }
 
-                if (ex is LdapException)
+                if (ex is LdapException ldapException)
                 {
-                    ldapex = (LdapException)ex;
+                    ldapex = ldapException;
                 }
                 else
                 {
@@ -2659,7 +2661,8 @@ namespace Novell.Directory.Ldap
                         agent = queue.MessageAgent;
                     }
 
-                    await agent.SendMessageAsync(rconn.Connection, newMsg, _defSearchCons.TimeLimit, null, ct).ConfigureAwait(false);
+                    await agent.SendMessageAsync(rconn.Connection, newMsg, _defSearchCons.TimeLimit, null, ct)
+                        .ConfigureAwait(false);
                 }
                 catch (InterThreadException ex)
                 {
@@ -2678,7 +2681,8 @@ namespace Novell.Directory.Ldap
                     // the stack unwinds back to the original and returns
                     // to the application.
                     // An exception is thrown for an error
-                    connList = await ChaseReferralAsync(queue, cons, null, null, hopCount, false, connList, ct).ConfigureAwait(false);
+                    connList = await ChaseReferralAsync(queue, cons, null, null, hopCount, false, connList, ct)
+                        .ConfigureAwait(false);
                 }
                 else
                 {
@@ -2686,13 +2690,12 @@ namespace Novell.Directory.Ldap
                     return connList;
                 }
             }
+            catch (LdapReferralException)
+            {
+                throw;
+            }
             catch (Exception ex)
             {
-                if (ex is LdapReferralException)
-                {
-                    throw (LdapReferralException)ex;
-                }
-
                 // Set referral list and failed referral
                 var rex = new LdapReferralException(ExceptionMessages.ReferralError, ex);
                 rex.SetReferrals(refs);

--- a/src/Novell.Directory.Ldap.NETStandard/LdapConstraints.cs
+++ b/src/Novell.Directory.Ldap.NETStandard/LdapConstraints.cs
@@ -264,21 +264,21 @@ namespace Novell.Directory.Ldap
         /// <param name="name">
         ///     Name of the property to set.
         /// </param>
-        /// <param name="valueRenamed">
+        /// <param name="value">
         ///     Value to assign to the property.
         ///     property is not supported.
         ///     @throws NullPointerException if name or value are null.
         /// </param>
         /// <seealso cref="LdapConnection.GetProperty">
         /// </seealso>
-        public void SetProperty(string name, object valueRenamed)
+        public void SetProperty(string name, object value)
         {
             if (_properties == null)
             {
                 _properties = new Hashtable();
             }
 
-            _properties.Add(name, valueRenamed);
+            _properties.Add(name, value);
         }
 
         /// <summary>

--- a/src/Novell.Directory.Ldap.NETStandard/LdapException.cs
+++ b/src/Novell.Directory.Ldap.NETStandard/LdapException.cs
@@ -1106,7 +1106,7 @@ namespace Novell.Directory.Ldap
         {
             get
             {
-                if (_serverMessage != null && _serverMessage.Length == 0)
+                if (_serverMessage is { Length: 0 })
                 {
                     return null;
                 }

--- a/src/Novell.Directory.Ldap.NETStandard/LdapExtendedRequest.cs
+++ b/src/Novell.Directory.Ldap.NETStandard/LdapExtendedRequest.cs
@@ -82,8 +82,8 @@ namespace Novell.Directory.Ldap
                 if (xreq.Count >= 2)
                 {
                     tag = (Asn1Tagged)xreq[1];
-                    var valueRenamed = (Asn1OctetString)tag.TaggedValue;
-                    requestValue = valueRenamed.ByteValue();
+                    var value = (Asn1OctetString)tag.TaggedValue;
+                    requestValue = value.ByteValue();
                 }
 
                 return new LdapExtendedOperation(requestId, requestValue);

--- a/src/Novell.Directory.Ldap.NETStandard/LdapExtendedRequest.cs
+++ b/src/Novell.Directory.Ldap.NETStandard/LdapExtendedRequest.cs
@@ -71,17 +71,17 @@ namespace Novell.Directory.Ldap
         {
             get
             {
-                var xreq = (RfcExtendedRequest)Asn1Object.get_Renamed(1);
+                var xreq = (RfcExtendedRequest)Asn1Object[1];
 
                 // Zeroth element is the OID, element one is the value
-                var tag = (Asn1Tagged)xreq.get_Renamed(0);
+                var tag = (Asn1Tagged)xreq[0];
                 var oid = (RfcLdapOid)tag.TaggedValue;
                 var requestId = oid.StringValue();
 
                 byte[] requestValue = null;
-                if (xreq.Size() >= 2)
+                if (xreq.Count >= 2)
                 {
-                    tag = (Asn1Tagged)xreq.get_Renamed(1);
+                    tag = (Asn1Tagged)xreq[1];
                     var valueRenamed = (Asn1OctetString)tag.TaggedValue;
                     requestValue = valueRenamed.ByteValue();
                 }

--- a/src/Novell.Directory.Ldap.NETStandard/LdapMessage.cs
+++ b/src/Novell.Directory.Ldap.NETStandard/LdapMessage.cs
@@ -280,14 +280,14 @@ namespace Novell.Directory.Ldap
                                                 */
                         var rfcCtl = asn1Ctrls[i];
                         var oid = rfcCtl.ControlType.StringValue();
-                        var valueRenamed = rfcCtl.ControlValue.ByteValue();
+                        var value = rfcCtl.ControlValue.ByteValue();
                         var critical = rfcCtl.Criticality.BooleanValue();
 
                         /* Return from this call should return either an LDAPControl
                         * or a class extending LDAPControl that implements the
                         * appropriate registered response control
                         */
-                        controls[i] = ControlFactory(oid, critical, valueRenamed);
+                        controls[i] = ControlFactory(oid, critical, value);
                     }
                 }
 
@@ -537,7 +537,7 @@ namespace Novell.Directory.Ldap
         ///     that control by calling its contructor.  Otherwise we default to
         ///     returning a regular LdapControl object.
         /// </summary>
-        private LdapControl ControlFactory(string oid, bool critical, byte[] valueRenamed)
+        private LdapControl ControlFactory(string oid, bool critical, byte[] value)
         {
             var regControls = LdapControl.RegisteredControls;
             /*
@@ -548,7 +548,7 @@ namespace Novell.Directory.Ldap
             {
                 try
                 {
-                    return responseFactory(oid, critical, valueRenamed);
+                    return responseFactory(oid, critical, value);
                 }
                 catch (Exception e)
                 {
@@ -561,7 +561,7 @@ namespace Novell.Directory.Ldap
 
             // If we get here we did not have a registered response control
             // for this oid.  Return a default LDAPControl object.
-            return new LdapControl(oid, critical, valueRenamed);
+            return new LdapControl(oid, critical, value);
         }
 
         /// <summary>

--- a/src/Novell.Directory.Ldap.NETStandard/LdapMessage.cs
+++ b/src/Novell.Directory.Ldap.NETStandard/LdapMessage.cs
@@ -262,8 +262,8 @@ namespace Novell.Directory.Ldap
                 // convert from RFC 2251 Controls to LDAPControl[].
                 if (asn1Ctrls != null)
                 {
-                    controls = new LdapControl[asn1Ctrls.Size()];
-                    for (var i = 0; i < asn1Ctrls.Size(); i++)
+                    controls = new LdapControl[asn1Ctrls.Count];
+                    for (var i = 0; i < asn1Ctrls.Count; i++)
                     {
                         /*
                                                 * At this point we have an RfcControl which needs to be
@@ -278,7 +278,7 @@ namespace Novell.Directory.Ldap
                                                 * we were parsing the control. Answer: By the time the
                                                 * code realizes that we have a control it is already too late.
                                                 */
-                        var rfcCtl = (RfcControl)asn1Ctrls.get_Renamed(i);
+                        var rfcCtl = asn1Ctrls[i];
                         var oid = rfcCtl.ControlType.StringValue();
                         var valueRenamed = rfcCtl.ControlValue.ByteValue();
                         var critical = rfcCtl.Criticality.BooleanValue();

--- a/src/Novell.Directory.Ldap.NETStandard/LdapModifyRequest.cs
+++ b/src/Novell.Directory.Ldap.NETStandard/LdapModifyRequest.cs
@@ -95,9 +95,9 @@ namespace Novell.Directory.Ldap
                 // Each modification consists of a mod type and a sequence
                 // containing the attr name and a set of values
                 var opSeq = (Asn1Sequence)mods[m];
-                if (opSeq.Size() != 2)
+                if (opSeq.Count != 2)
                 {
-                    throw new Exception("LdapModifyRequest: modification " + m + " is wrong size: " + opSeq.Size());
+                    throw new Exception("LdapModifyRequest: modification " + m + " is wrong size: " + opSeq.Count);
                 }
 
                 // Contains operation and sequence for the attribute
@@ -154,9 +154,11 @@ namespace Novell.Directory.Ldap
                 }
 
                 // create SEQUENCE containing mod operation and attr type and vals
-                var rfcMod = new Asn1Sequence(2);
-                rfcMod.Add(new Asn1Enumerated(mod.Op));
-                rfcMod.Add(new RfcAttributeTypeAndValues(new RfcAttributeDescription(attr.Name), vals));
+                var rfcMod = new Asn1Sequence(2)
+                {
+                    new Asn1Enumerated(mod.Op),
+                    new RfcAttributeTypeAndValues(new RfcAttributeDescription(attr.Name), vals),
+                };
 
                 // place SEQUENCE into SEQUENCE OF
                 rfcMods.Add(rfcMod);

--- a/src/Novell.Directory.Ldap.NETStandard/LdapResponse.cs
+++ b/src/Novell.Directory.Ldap.NETStandard/LdapResponse.cs
@@ -190,20 +190,20 @@ namespace Novell.Directory.Ldap
             get
             {
                 string[] referrals;
-                var refRenamed = ((IRfcResponse)Message.Response).GetReferral();
+                var referral = ((IRfcResponse)Message.Response).GetReferral();
 
-                if (refRenamed == null)
+                if (referral == null)
                 {
                     referrals = new string[0];
                 }
                 else
                 {
                     // convert RFC 2251 Referral to String[]
-                    var size = refRenamed.Count;
+                    var size = referral.Count;
                     referrals = new string[size];
                     for (var i = 0; i < size; i++)
                     {
-                        var aRef = ((Asn1OctetString)refRenamed[i]).StringValue();
+                        var aRef = ((Asn1OctetString)referral[i]).StringValue();
                         try
                         {
                             // get the referral URL

--- a/src/Novell.Directory.Ldap.NETStandard/LdapResponse.cs
+++ b/src/Novell.Directory.Ldap.NETStandard/LdapResponse.cs
@@ -199,11 +199,11 @@ namespace Novell.Directory.Ldap
                 else
                 {
                     // convert RFC 2251 Referral to String[]
-                    var size = refRenamed.Size();
+                    var size = refRenamed.Count;
                     referrals = new string[size];
                     for (var i = 0; i < size; i++)
                     {
-                        var aRef = ((Asn1OctetString)refRenamed.get_Renamed(i)).StringValue();
+                        var aRef = ((Asn1OctetString)refRenamed[i]).StringValue();
                         try
                         {
                             // get the referral URL

--- a/src/Novell.Directory.Ldap.NETStandard/LdapSchema.cs
+++ b/src/Novell.Directory.Ldap.NETStandard/LdapSchema.cs
@@ -521,7 +521,7 @@ namespace Novell.Directory.Ldap
             }
 
             var c = key[0];
-            if (c >= '0' && c <= '9')
+            if (c is >= '0' and <= '9')
             {
                 // oid lookup
                 return idTable[key];

--- a/src/Novell.Directory.Ldap.NETStandard/LdapSchema.cs
+++ b/src/Novell.Directory.Ldap.NETStandard/LdapSchema.cs
@@ -254,12 +254,12 @@ namespace Novell.Directory.Ldap
 
                 if (attrName.EqualsOrdinalCI(SchemaTypeNames[ObjectClass]))
                 {
-                    foreach (var valueRenamed in attr.StringValueArray)
+                    foreach (var value in attr.StringValueArray)
                     {
                         LdapObjectClassSchema classSchema;
                         try
                         {
-                            classSchema = new LdapObjectClassSchema(valueRenamed);
+                            classSchema = new LdapObjectClassSchema(value);
                         }
                         catch (Exception e)
                         {
@@ -272,12 +272,12 @@ namespace Novell.Directory.Ldap
                 }
                 else if (attrName.EqualsOrdinalCI(SchemaTypeNames[Attribute]))
                 {
-                    foreach (var valueRenamed in attr.StringValueArray)
+                    foreach (var value in attr.StringValueArray)
                     {
                         LdapAttributeSchema attrSchema;
                         try
                         {
-                            attrSchema = new LdapAttributeSchema(valueRenamed);
+                            attrSchema = new LdapAttributeSchema(value);
                         }
                         catch (Exception e)
                         {
@@ -290,49 +290,49 @@ namespace Novell.Directory.Ldap
                 }
                 else if (attrName.EqualsOrdinalCI(SchemaTypeNames[Syntax]))
                 {
-                    foreach (var valueRenamed in attr.StringValueArray)
+                    foreach (var value in attr.StringValueArray)
                     {
-                        var syntaxSchema = new LdapSyntaxSchema(valueRenamed);
+                        var syntaxSchema = new LdapSyntaxSchema(value);
                         AddElement(_syntaxIdTable, _syntaxNameTable, syntaxSchema);
                     }
                 }
                 else if (attrName.EqualsOrdinalCI(SchemaTypeNames[Matching]))
                 {
-                    foreach (var valueRenamed in attr.StringValueArray)
+                    foreach (var value in attr.StringValueArray)
                     {
-                        var matchingRuleSchema = new LdapMatchingRuleSchema(valueRenamed, null);
+                        var matchingRuleSchema = new LdapMatchingRuleSchema(value, null);
                         AddElement(_matchingIdTable, _matchingNameTable, matchingRuleSchema);
                     }
                 }
                 else if (attrName.EqualsOrdinalCI(SchemaTypeNames[MatchingUse]))
                 {
-                    foreach (var valueRenamed in attr.StringValueArray)
+                    foreach (var value in attr.StringValueArray)
                     {
-                        var matchingRuleUseSchema = new LdapMatchingRuleUseSchema(valueRenamed);
+                        var matchingRuleUseSchema = new LdapMatchingRuleUseSchema(value);
                         AddElement(_matchingUseIdTable, _matchingUseNameTable, matchingRuleUseSchema);
                     }
                 }
                 else if (attrName.EqualsOrdinalCI(SchemaTypeNames[Ditcontent]))
                 {
-                    foreach (var valueRenamed in attr.StringValueArray)
+                    foreach (var value in attr.StringValueArray)
                     {
-                        var dItContentRuleSchema = new LdapDitContentRuleSchema(valueRenamed);
+                        var dItContentRuleSchema = new LdapDitContentRuleSchema(value);
                         AddElement(_ditcontentIdTable, _ditcontentNameTable, dItContentRuleSchema);
                     }
                 }
                 else if (attrName.EqualsOrdinalCI(SchemaTypeNames[Ditstructure]))
                 {
-                    foreach (var valueRenamed in attr.StringValueArray)
+                    foreach (var value in attr.StringValueArray)
                     {
-                        var dItStructureRuleSchema = new LdapDitStructureRuleSchema(valueRenamed);
+                        var dItStructureRuleSchema = new LdapDitStructureRuleSchema(value);
                         AddElement(_ditstructureIdTable, _ditstructureNameTable, dItStructureRuleSchema);
                     }
                 }
                 else if (attrName.EqualsOrdinalCI(SchemaTypeNames[NameForm]))
                 {
-                    foreach (var valueRenamed in attr.StringValueArray)
+                    foreach (var value in attr.StringValueArray)
                     {
-                        var nameFormSchema = new LdapNameFormSchema(valueRenamed);
+                        var nameFormSchema = new LdapNameFormSchema(value);
                         AddElement(_nameFormIdTable, _nameFormNameTable, nameFormSchema);
                     }
                 }

--- a/src/Novell.Directory.Ldap.NETStandard/LdapSchemaElement.cs
+++ b/src/Novell.Directory.Ldap.NETStandard/LdapSchemaElement.cs
@@ -226,7 +226,7 @@ namespace Novell.Directory.Ldap
         ///     @throws UnsupportedOperationException always thrown since
         ///     LdapSchemaElement is read-only.
         /// </summary>
-        public override void RemoveValue(string valueRenamed)
+        public override void RemoveValue(string value)
         {
             throw new NotSupportedException("removeValue is not supported by LdapSchemaElement");
         }
@@ -237,7 +237,7 @@ namespace Novell.Directory.Ldap
         ///     @throws UnsupportedOperationException always thrown since
         ///     LdapSchemaElement is read-only.
         /// </summary>
-        public override void RemoveValue(byte[] valueRenamed)
+        public override void RemoveValue(byte[] value)
         {
             throw new NotSupportedException("removeValue is not supported by LdapSchemaElement");
         }

--- a/src/Novell.Directory.Ldap.NETStandard/LdapSearchConstraints.cs
+++ b/src/Novell.Directory.Ldap.NETStandard/LdapSearchConstraints.cs
@@ -116,9 +116,8 @@ namespace Novell.Directory.Ldap
                 Properties = (Hashtable)lp.Clone();
             }
 
-            if (cons is LdapSearchConstraints)
+            if (cons is LdapSearchConstraints scons)
             {
-                var scons = (LdapSearchConstraints)cons;
                 ServerTimeLimit = scons.ServerTimeLimit;
                 Dereference = scons.Dereference;
                 MaxResults = scons.MaxResults;

--- a/src/Novell.Directory.Ldap.NETStandard/LdapSearchRequest.cs
+++ b/src/Novell.Directory.Ldap.NETStandard/LdapSearchRequest.cs
@@ -265,7 +265,7 @@ namespace Novell.Directory.Ldap
         /// </seealso>
         /// <seealso cref="LdapConnection.ScopeSub">
         /// </seealso>
-        public int Scope => ((Asn1Enumerated)((RfcSearchRequest)Asn1Object.get_Renamed(1)).get_Renamed(1)).IntValue();
+        public int Scope => ((Asn1Enumerated)((RfcSearchRequest)Asn1Object[1])[1]).IntValue();
 
         /// <summary> Retrieves the behaviour of dereferencing aliases on a search request.</summary>
         /// <returns>
@@ -280,7 +280,7 @@ namespace Novell.Directory.Ldap
         /// <seealso cref="LdapSearchConstraints.DerefSearching">
         /// </seealso>
         public int Dereference =>
-            ((Asn1Enumerated)((RfcSearchRequest)Asn1Object.get_Renamed(1)).get_Renamed(2)).IntValue();
+            ((Asn1Enumerated)((RfcSearchRequest)Asn1Object[1])[2]).IntValue();
 
         /// <summary>
         ///     Retrieves the maximum number of entries to be returned on a search.
@@ -289,7 +289,7 @@ namespace Novell.Directory.Ldap
         ///     Maximum number of search entries.
         /// </returns>
         public int MaxResults =>
-            ((Asn1Integer)((RfcSearchRequest)Asn1Object.get_Renamed(1)).get_Renamed(3)).IntValue();
+            ((Asn1Integer)((RfcSearchRequest)Asn1Object[1])[3]).IntValue();
 
         /// <summary>
         ///     Retrieves the server time limit for a search request.
@@ -298,7 +298,7 @@ namespace Novell.Directory.Ldap
         ///     server time limit in nanoseconds.
         /// </returns>
         public int ServerTimeLimit =>
-            ((Asn1Integer)((RfcSearchRequest)Asn1Object.get_Renamed(1)).get_Renamed(4)).IntValue();
+            ((Asn1Integer)((RfcSearchRequest)Asn1Object[1])[4]).IntValue();
 
         /// <summary>
         ///     Retrieves whether attribute values or only attribute types(names) should
@@ -309,7 +309,7 @@ namespace Novell.Directory.Ldap
         ///     attributes types and values are to be returned.
         /// </returns>
         public bool TypesOnly =>
-            ((Asn1Boolean)((RfcSearchRequest)Asn1Object.get_Renamed(1)).get_Renamed(5)).BooleanValue();
+            ((Asn1Boolean)((RfcSearchRequest)Asn1Object[1])[5]).BooleanValue();
 
         /// <summary> Retrieves an array of attribute names to request for in a search.</summary>
         /// <returns>
@@ -319,12 +319,12 @@ namespace Novell.Directory.Ldap
         {
             get
             {
-                var attrs = (RfcAttributeDescriptionList)((RfcSearchRequest)Asn1Object.get_Renamed(1)).get_Renamed(7);
+                var attrs = (RfcAttributeDescriptionList)((RfcSearchRequest)Asn1Object[1])[7];
 
-                var rAttrs = new string[attrs.Size()];
+                var rAttrs = new string[attrs.Count];
                 for (var i = 0; i < rAttrs.Length; i++)
                 {
-                    rAttrs[i] = ((RfcAttributeDescription)attrs.get_Renamed(i)).StringValue();
+                    rAttrs[i] = ((RfcAttributeDescription)attrs[i]).StringValue();
                 }
 
                 return rAttrs;
@@ -341,7 +341,7 @@ namespace Novell.Directory.Ldap
         /// <returns>
         ///     filter object for a search request.
         /// </returns>
-        private RfcFilter RfcFilter => (RfcFilter)((RfcSearchRequest)Asn1Object.get_Renamed(1)).get_Renamed(6);
+        private RfcFilter RfcFilter => (RfcFilter)((RfcSearchRequest)Asn1Object[1])[6];
 
         /// <summary>
         ///     Retrieves an IEnumerable object representing the parsed filter for

--- a/src/Novell.Directory.Ldap.NETStandard/LdapSearchRequest.cs
+++ b/src/Novell.Directory.Ldap.NETStandard/LdapSearchRequest.cs
@@ -110,7 +110,7 @@ namespace Novell.Directory.Ldap
         /// <summary>
         ///     Constructs an Ldap Search Request.
         /// </summary>
-        /// <param name="baseRenamed">
+        /// <param name="baseDn">
         ///     The base distinguished name to search from.
         /// </param>
         /// <param name="scope">
@@ -167,11 +167,11 @@ namespace Novell.Directory.Ldap
         /// <seealso cref="LdapConnection.SearchAsync(string,int,string,string[],bool,LdapSearchConstraints,CancellationToken)"/>
         /// <seealso cref="LdapConnection.SearchAsync(string,int,string,string[],bool,LdapSearchQueue,LdapSearchConstraints,CancellationToken)"/>
         /// <seealso cref="LdapSearchConstraints"/>
-        public LdapSearchRequest(string baseRenamed, int scope, string filter, string[] attrs, int dereference,
+        public LdapSearchRequest(string baseDn, int scope, string filter, string[] attrs, int dereference,
             int maxResults, int serverTimeLimit, bool typesOnly, LdapControl[] cont)
             : base(
                 SearchRequest,
-                new RfcSearchRequest(new RfcLdapDn(baseRenamed), new Asn1Enumerated(scope),
+                new RfcSearchRequest(new RfcLdapDn(baseDn), new Asn1Enumerated(scope),
                     new Asn1Enumerated(dereference), new Asn1Integer(maxResults), new Asn1Integer(serverTimeLimit),
                     new Asn1Boolean(typesOnly), new RfcFilter(filter), new RfcAttributeDescriptionList(attrs)), cont)
         {
@@ -180,7 +180,7 @@ namespace Novell.Directory.Ldap
         /// <summary>
         ///     Constructs an Ldap Search Request with a filter in Asn1 format.
         /// </summary>
-        /// <param name="baseRenamed">
+        /// <param name="baseDn">
         ///     The base distinguished name to search from.
         /// </param>
         /// <param name="scope">
@@ -237,11 +237,11 @@ namespace Novell.Directory.Ldap
         /// <seealso cref="LdapConnection.SearchAsync(string,int,string,string[],bool,LdapSearchConstraints,CancellationToken)"/>
         /// <seealso cref="LdapConnection.SearchAsync(string,int,string,string[],bool,LdapSearchQueue,LdapSearchConstraints,CancellationToken)"/>
         /// <seealso cref="LdapSearchConstraints"/>
-        public LdapSearchRequest(string baseRenamed, int scope, RfcFilter filter, string[] attrs, int dereference,
+        public LdapSearchRequest(string baseDn, int scope, RfcFilter filter, string[] attrs, int dereference,
             int maxResults, int serverTimeLimit, bool typesOnly, LdapControl[] cont)
             : base(
                 SearchRequest,
-                new RfcSearchRequest(new RfcLdapDn(baseRenamed), new Asn1Enumerated(scope),
+                new RfcSearchRequest(new RfcLdapDn(baseDn), new Asn1Enumerated(scope),
                     new Asn1Enumerated(dereference), new Asn1Integer(maxResults), new Asn1Integer(serverTimeLimit),
                     new Asn1Boolean(typesOnly), filter, new RfcAttributeDescriptionList(attrs)), cont)
         {

--- a/src/Novell.Directory.Ldap.NETStandard/LdapSearchResult.cs
+++ b/src/Novell.Directory.Ldap.NETStandard/LdapSearchResult.cs
@@ -91,11 +91,10 @@ namespace Novell.Directory.Ldap
                         var seq = (Asn1Sequence)seqArray[i];
                         var attr = new LdapAttribute(((Asn1OctetString)seq[0]).StringValue());
 
-                        var setRenamed = (Asn1Set)seq[1];
-                        var setArray = setRenamed.ToArray();
-                        for (var j = 0; j < setArray.Length; j++)
+                        var set = (Asn1Set)seq[1];
+                        foreach (Asn1OctetString octectString in set)
                         {
-                            attr.AddValue(((Asn1OctetString)setArray[j]).ByteValue());
+                            attr.AddValue(octectString.ByteValue());
                         }
 
                         attrs.Add(attr);

--- a/src/Novell.Directory.Ldap.NETStandard/LdapSearchResult.cs
+++ b/src/Novell.Directory.Ldap.NETStandard/LdapSearchResult.cs
@@ -89,10 +89,10 @@ namespace Novell.Directory.Ldap
                     for (var i = 0; i < seqArray.Length; i++)
                     {
                         var seq = (Asn1Sequence)seqArray[i];
-                        var attr = new LdapAttribute(((Asn1OctetString)seq.get_Renamed(0)).StringValue());
+                        var attr = new LdapAttribute(((Asn1OctetString)seq[0]).StringValue());
 
-                        var setRenamed = (Asn1Set)seq.get_Renamed(1);
-                        object[] setArray = setRenamed.ToArray();
+                        var setRenamed = (Asn1Set)seq[1];
+                        var setArray = setRenamed.ToArray();
                         for (var j = 0; j < setArray.Length; j++)
                         {
                             attr.AddValue(((Asn1OctetString)setArray[j]).ByteValue());

--- a/src/Novell.Directory.Ldap.NETStandard/LdapSearchResults.cs
+++ b/src/Novell.Directory.Ldap.NETStandard/LdapSearchResults.cs
@@ -123,12 +123,11 @@ namespace Novell.Directory.Ldap
             {
                 // Check for Search Entries and the Search Result
                 element = _entries[_entryIndex++];
-                if (element is LdapResponse)
+                if (element is LdapResponse lr)
                 {
                     // Search done w/bad status
-                    if (((LdapResponse)element).HasException())
+                    if (lr.HasException())
                     {
-                        var lr = (LdapResponse)element;
                         var ri = lr.ActiveReferral;
 
                         if (ri != null)
@@ -142,11 +141,11 @@ namespace Novell.Directory.Ldap
                     }
 
                     // Throw an exception if not success
-                    ((LdapResponse)element).ChkResultCode();
+                    lr.ChkResultCode();
                 }
-                else if (element is LdapException)
+                else if (element is LdapException exception)
                 {
-                    throw (LdapException)element;
+                    throw exception;
                 }
             }
             else
@@ -220,22 +219,22 @@ namespace Novell.Directory.Ldap
                             ResponseControls = ldapMessage.Controls;
                         }
 
-                        if (ldapMessage is LdapSearchResult)
+                        if (ldapMessage is LdapSearchResult result)
                         {
                             // Search Entry
-                            object entry = ((LdapSearchResult)ldapMessage).Entry;
+                            object entry = result.Entry;
                             _entries.Add(entry);
                             i++;
                             _entryCount++;
                         }
-                        else if (ldapMessage is LdapSearchResultReference)
+                        else if (ldapMessage is LdapSearchResultReference reference)
                         {
                             // Search Ref
-                            var refs = ((LdapSearchResultReference)ldapMessage).Referrals;
+                            var refs = reference.Referrals;
 
                             if (_cons.ReferralFollowing)
                             {
-                                _referralConn = await _conn.ChaseReferralAsync(_queue, _cons, ldapMessage, refs, 0, true, _referralConn, ct).ConfigureAwait(false);
+                                _referralConn = await _conn.ChaseReferralAsync(_queue, _cons, reference, refs, 0, true, _referralConn, ct).ConfigureAwait(false);
                             }
                             else
                             {

--- a/src/Novell.Directory.Ldap.NETStandard/LdapSyntaxSchema.cs
+++ b/src/Novell.Directory.Ldap.NETStandard/LdapSyntaxSchema.cs
@@ -127,26 +127,19 @@ namespace Novell.Directory.Ldap
             {
                 valueBuffer.Append(" " + qualName + " ");
                 var qualValue = GetQualifier(qualName);
-                if (qualValue != null)
+                if (qualValue is { Length: > 1 })
                 {
-                    if (qualValue.Length > 1)
+                    valueBuffer.Append("( '");
+
+                    valueBuffer.Append(qualValue[0]);
+
+                    for (var i = 1; i < qualValue.Length; i++)
                     {
-                        valueBuffer.Append("( ");
-                        for (var i = 0; i < qualValue.Length; i++)
-                        {
-                            if (i > 0)
-                            {
-                                valueBuffer.Append(" ");
-                            }
-
-                            valueBuffer.Append("'" + qualValue[i] + "'");
-                        }
-
-                        if (qualValue.Length > 1)
-                        {
-                            valueBuffer.Append(" )");
-                        }
+                        valueBuffer.Append("' '");
+                        valueBuffer.Append(qualValue[i]);
                     }
+
+                    valueBuffer.Append("' )");
                 }
             }
 

--- a/src/Novell.Directory.Ldap.NETStandard/Message.cs
+++ b/src/Novell.Directory.Ldap.NETStandard/Message.cs
@@ -44,7 +44,7 @@ namespace Novell.Directory.Ldap
         private readonly Queue<object> _replies; // place to store replies
         private string _stackTraceCleanup;
         private ThreadClass _timer; // Timeout thread
-        private bool _waitForReplyRenamedField = true; // true if wait for reply
+        private bool _waitForReply = true; // true if wait for reply
 
         internal Message(LdapMessage msg, int mslimit, Connection conn, MessageAgent agent, BindProperties bindprops)
         {
@@ -190,12 +190,12 @@ namespace Novell.Directory.Ldap
             // sync on message so don't confuse with timer thread
             lock (_replies)
             {
-                while (_waitForReplyRenamedField)
+                while (_waitForReply)
                 {
                     if (_replies.Count == 0)
                     {
                         Monitor.Wait(_replies, _mslimit);
-                        if (_waitForReplyRenamedField)
+                        if (_waitForReply)
                         {
                             continue;
                         }
@@ -257,13 +257,13 @@ namespace Novell.Directory.Ldap
 
         internal void Abandon(LdapConstraints cons, InterThreadException informUserEx)
         {
-            if (!_waitForReplyRenamedField)
+            if (!_waitForReply)
             {
                 return;
             }
 
             _acceptReplies = false; // don't listen to anyone
-            _waitForReplyRenamedField = false; // don't let sleeping threads lie
+            _waitForReply = false; // don't let sleeping threads lie
             if (!Complete)
             {
                 try

--- a/src/Novell.Directory.Ldap.NETStandard/Rfc2251/RfcAbandonRequest.cs
+++ b/src/Novell.Directory.Ldap.NETStandard/Rfc2251/RfcAbandonRequest.cs
@@ -44,7 +44,7 @@ namespace Novell.Directory.Ldap.Rfc2251
         {
         }
 
-        public IRfcRequest DupRequest(string baseRenamed, string filter, bool reference)
+        public IRfcRequest DupRequest(string baseDn, string filter, bool reference)
         {
             throw new LdapException(ExceptionMessages.NoDupRequest, new object[] { "Abandon" },
                 LdapException.LdapNotSupported, null);

--- a/src/Novell.Directory.Ldap.NETStandard/Rfc2251/RfcAddRequest.cs
+++ b/src/Novell.Directory.Ldap.NETStandard/Rfc2251/RfcAddRequest.cs
@@ -70,12 +70,12 @@ namespace Novell.Directory.Ldap.Rfc2251
             // Replace the base if specified, otherwise keep original base
             if (baseRenamed != null)
             {
-                set_Renamed(0, new RfcLdapDn(baseRenamed));
+                this[0] = new RfcLdapDn(baseRenamed);
             }
         }
 
         /// <summary> Gets the attributes of the entry.</summary>
-        public RfcAttributeList Attributes => (RfcAttributeList)get_Renamed(1);
+        public RfcAttributeList Attributes => (RfcAttributeList)this[1];
 
         public IRfcRequest DupRequest(string baseRenamed, string filter, bool request)
         {
@@ -84,7 +84,7 @@ namespace Novell.Directory.Ldap.Rfc2251
 
         public string GetRequestDn()
         {
-            return ((RfcLdapDn)get_Renamed(0)).StringValue();
+            return ((RfcLdapDn)this[0]).StringValue();
         }
 
         // *************************************************************************

--- a/src/Novell.Directory.Ldap.NETStandard/Rfc2251/RfcAddRequest.cs
+++ b/src/Novell.Directory.Ldap.NETStandard/Rfc2251/RfcAddRequest.cs
@@ -61,25 +61,25 @@ namespace Novell.Directory.Ldap.Rfc2251
         /// <param name="origRequest">
         ///     the original request data.
         /// </param>
-        /// <param name="baseRenamed">
+        /// <param name="baseDn">
         ///     if not null, replaces the dn of the original request.
         /// </param>
-        internal RfcAddRequest(Asn1Object[] origRequest, string baseRenamed)
+        internal RfcAddRequest(Asn1Object[] origRequest, string baseDn)
             : base(origRequest, origRequest.Length)
         {
             // Replace the base if specified, otherwise keep original base
-            if (baseRenamed != null)
+            if (baseDn != null)
             {
-                this[0] = new RfcLdapDn(baseRenamed);
+                this[0] = new RfcLdapDn(baseDn);
             }
         }
 
         /// <summary> Gets the attributes of the entry.</summary>
         public RfcAttributeList Attributes => (RfcAttributeList)this[1];
 
-        public IRfcRequest DupRequest(string baseRenamed, string filter, bool request)
+        public IRfcRequest DupRequest(string baseDn, string filter, bool request)
         {
-            return new RfcAddRequest(ToArray(), baseRenamed);
+            return new RfcAddRequest(ToArray(), baseDn);
         }
 
         public string GetRequestDn()

--- a/src/Novell.Directory.Ldap.NETStandard/Rfc2251/RfcAddResponse.cs
+++ b/src/Novell.Directory.Ldap.NETStandard/Rfc2251/RfcAddResponse.cs
@@ -42,8 +42,8 @@ namespace Novell.Directory.Ldap.Rfc2251
         ///     The only time a client will create a AddResponse is when it is
         ///     decoding it from an InputStream.
         /// </summary>
-        public RfcAddResponse(IAsn1Decoder dec, Stream inRenamed, int len)
-            : base(dec, inRenamed, len)
+        public RfcAddResponse(IAsn1Decoder dec, Stream input, int len)
+            : base(dec, input, len)
         {
         }
 

--- a/src/Novell.Directory.Ldap.NETStandard/Rfc2251/RfcAssertionValue.cs
+++ b/src/Novell.Directory.Ldap.NETStandard/Rfc2251/RfcAssertionValue.cs
@@ -34,8 +34,8 @@ namespace Novell.Directory.Ldap.Rfc2251
     public class RfcAssertionValue : Asn1OctetString
     {
         /// <summary> </summary>
-        public RfcAssertionValue(byte[] valueRenamed)
-            : base(valueRenamed)
+        public RfcAssertionValue(byte[] value)
+            : base(value)
         {
         }
     }

--- a/src/Novell.Directory.Ldap.NETStandard/Rfc2251/RfcAttributeDescription.cs
+++ b/src/Novell.Directory.Ldap.NETStandard/Rfc2251/RfcAttributeDescription.cs
@@ -39,8 +39,8 @@ namespace Novell.Directory.Ldap.Rfc2251
         }
 
         /// <summary> </summary>
-        public RfcAttributeDescription(IAsn1Decoder dec, Stream inRenamed, int len)
-            : base(dec, inRenamed, len)
+        public RfcAttributeDescription(IAsn1Decoder dec, Stream input, int len)
+            : base(dec, input, len)
         {
         }
     }

--- a/src/Novell.Directory.Ldap.NETStandard/Rfc2251/RfcAttributeValue.cs
+++ b/src/Novell.Directory.Ldap.NETStandard/Rfc2251/RfcAttributeValue.cs
@@ -32,14 +32,14 @@ namespace Novell.Directory.Ldap.Rfc2251
     public class RfcAttributeValue : Asn1OctetString
     {
         /// <summary> </summary>
-        public RfcAttributeValue(string valueRenamed)
-            : base(valueRenamed)
+        public RfcAttributeValue(string value)
+            : base(value)
         {
         }
 
         /// <summary> </summary>
-        public RfcAttributeValue(byte[] valueRenamed)
-            : base(valueRenamed)
+        public RfcAttributeValue(byte[] value)
+            : base(value)
         {
         }
     }

--- a/src/Novell.Directory.Ldap.NETStandard/Rfc2251/RfcAttributeValueAssertion.cs
+++ b/src/Novell.Directory.Ldap.NETStandard/Rfc2251/RfcAttributeValueAssertion.cs
@@ -57,7 +57,7 @@ namespace Novell.Directory.Ldap.Rfc2251
         /// <returns>
         ///     the attribute description.
         /// </returns>
-        public string AttributeDescription => ((RfcAttributeDescription)get_Renamed(0)).StringValue();
+        public string AttributeDescription => ((RfcAttributeDescription)this[0]).StringValue();
 
         /// <summary>
         ///     Returns the assertion value.
@@ -65,6 +65,6 @@ namespace Novell.Directory.Ldap.Rfc2251
         /// <returns>
         ///     the assertion value.
         /// </returns>
-        public byte[] AssertionValue => ((RfcAssertionValue)get_Renamed(1)).ByteValue();
+        public byte[] AssertionValue => ((RfcAssertionValue)this[1]).ByteValue();
     }
 }

--- a/src/Novell.Directory.Ldap.NETStandard/Rfc2251/RfcBindRequest.cs
+++ b/src/Novell.Directory.Ldap.NETStandard/Rfc2251/RfcBindRequest.cs
@@ -66,13 +66,13 @@ namespace Novell.Directory.Ldap.Rfc2251
         ///     Constructs a new Bind Request copying the original data from
         ///     an existing request.
         /// </summary>
-        internal RfcBindRequest(Asn1Object[] origRequest, string baseRenamed)
+        internal RfcBindRequest(Asn1Object[] origRequest, string baseDn)
             : base(origRequest, origRequest.Length)
         {
             // Replace the dn if specified, otherwise keep original base
-            if (baseRenamed != null)
+            if (baseDn != null)
             {
-                this[1] = new RfcLdapDn(baseRenamed);
+                this[1] = new RfcLdapDn(baseDn);
             }
         }
 
@@ -103,9 +103,9 @@ namespace Novell.Directory.Ldap.Rfc2251
             set => this[2] = value;
         }
 
-        public IRfcRequest DupRequest(string baseRenamed, string filter, bool request)
+        public IRfcRequest DupRequest(string baseDn, string filter, bool request)
         {
-            return new RfcBindRequest(ToArray(), baseRenamed);
+            return new RfcBindRequest(ToArray(), baseDn);
         }
 
         public string GetRequestDn()

--- a/src/Novell.Directory.Ldap.NETStandard/Rfc2251/RfcBindRequest.cs
+++ b/src/Novell.Directory.Ldap.NETStandard/Rfc2251/RfcBindRequest.cs
@@ -72,7 +72,7 @@ namespace Novell.Directory.Ldap.Rfc2251
             // Replace the dn if specified, otherwise keep original base
             if (baseRenamed != null)
             {
-                set_Renamed(1, new RfcLdapDn(baseRenamed));
+                this[1] = new RfcLdapDn(baseRenamed);
             }
         }
 
@@ -80,27 +80,27 @@ namespace Novell.Directory.Ldap.Rfc2251
         /// <summary> Sets the protocol version.</summary>
         public Asn1Integer Version
         {
-            get => (Asn1Integer)get_Renamed(0);
+            get => (Asn1Integer)this[0];
 
-            set => set_Renamed(0, value);
+            set => this[0] = value;
         }
 
         /// <summary> </summary>
         /// <summary> </summary>
         public RfcLdapDn Name
         {
-            get => (RfcLdapDn)get_Renamed(1);
+            get => (RfcLdapDn)this[1];
 
-            set => set_Renamed(1, value);
+            set => this[1] = value;
         }
 
         /// <summary> </summary>
         /// <summary> </summary>
         public RfcAuthenticationChoice AuthenticationChoice
         {
-            get => (RfcAuthenticationChoice)get_Renamed(2);
+            get => (RfcAuthenticationChoice)this[2];
 
-            set => set_Renamed(2, value);
+            set => this[2] = value;
         }
 
         public IRfcRequest DupRequest(string baseRenamed, string filter, bool request)
@@ -110,7 +110,7 @@ namespace Novell.Directory.Ldap.Rfc2251
 
         public string GetRequestDn()
         {
-            return ((RfcLdapDn)get_Renamed(1)).StringValue();
+            return ((RfcLdapDn)this[1]).StringValue();
         }
 
         // *************************************************************************

--- a/src/Novell.Directory.Ldap.NETStandard/Rfc2251/RfcBindResponse.cs
+++ b/src/Novell.Directory.Ldap.NETStandard/Rfc2251/RfcBindResponse.cs
@@ -46,8 +46,8 @@ namespace Novell.Directory.Ldap.Rfc2251
         ///     Note: If serverSaslCreds is included in the BindResponse, it does not
         ///     need to be decoded since it is already an OCTET STRING.
         /// </summary>
-        public RfcBindResponse(IAsn1Decoder dec, Stream inRenamed, int len)
-            : base(dec, inRenamed, len)
+        public RfcBindResponse(IAsn1Decoder dec, Stream input, int len)
+            : base(dec, input, len)
         {
             // Decode optional referral from Asn1OctetString to Referral.
             if (Count > 3)

--- a/src/Novell.Directory.Ldap.NETStandard/Rfc2251/RfcBindResponse.cs
+++ b/src/Novell.Directory.Ldap.NETStandard/Rfc2251/RfcBindResponse.cs
@@ -50,15 +50,15 @@ namespace Novell.Directory.Ldap.Rfc2251
             : base(dec, inRenamed, len)
         {
             // Decode optional referral from Asn1OctetString to Referral.
-            if (Size() > 3)
+            if (Count > 3)
             {
-                var obj = (Asn1Tagged)get_Renamed(3);
+                var obj = (Asn1Tagged)this[3];
                 var id = obj.GetIdentifier();
                 if (id.Tag == RfcLdapResult.Referral)
                 {
                     var content = ((Asn1OctetString)obj.TaggedValue).ByteValue();
                     var bais = new MemoryStream(content);
-                    set_Renamed(3, new RfcReferral(dec, bais, content.Length));
+                    this[3] = new RfcReferral(dec, bais, content.Length);
                 }
             }
         }
@@ -71,18 +71,18 @@ namespace Novell.Directory.Ldap.Rfc2251
         {
             get
             {
-                if (Size() == 5)
+                if (Count == 5)
                 {
-                    return (Asn1OctetString)((Asn1Tagged)get_Renamed(4)).TaggedValue;
+                    return (Asn1OctetString)((Asn1Tagged)this[4]).TaggedValue;
                 }
 
-                if (Size() == 4)
+                if (Count == 4)
                 {
                     // could be referral or serverSaslCreds
-                    var obj = get_Renamed(3);
-                    if (obj is Asn1Tagged)
+                    var obj = this[3];
+                    if (obj is Asn1Tagged tagged)
                     {
-                        return (Asn1OctetString)((Asn1Tagged)obj).TaggedValue;
+                        return (Asn1OctetString)tagged.TaggedValue;
                     }
                 }
 
@@ -97,30 +97,30 @@ namespace Novell.Directory.Ldap.Rfc2251
         /// <summary> </summary>
         public Asn1Enumerated GetResultCode()
         {
-            return (Asn1Enumerated)get_Renamed(0);
+            return (Asn1Enumerated)this[0];
         }
 
         /// <summary> </summary>
         public RfcLdapDn GetMatchedDn()
         {
-            return new RfcLdapDn(((Asn1OctetString)get_Renamed(1)).ByteValue());
+            return new RfcLdapDn(((Asn1OctetString)this[1]).ByteValue());
         }
 
         /// <summary> </summary>
         public RfcLdapString GetErrorMessage()
         {
-            return new RfcLdapString(((Asn1OctetString)get_Renamed(2)).ByteValue());
+            return new RfcLdapString(((Asn1OctetString)this[2]).ByteValue());
         }
 
         /// <summary> </summary>
         public RfcReferral GetReferral()
         {
-            if (Size() > 3)
+            if (Count > 3)
             {
-                var obj = get_Renamed(3);
-                if (obj is RfcReferral)
+                var obj = this[3];
+                if (obj is RfcReferral referral)
                 {
-                    return (RfcReferral)obj;
+                    return referral;
                 }
             }
 

--- a/src/Novell.Directory.Ldap.NETStandard/Rfc2251/RfcCompareRequest.cs
+++ b/src/Novell.Directory.Ldap.NETStandard/Rfc2251/RfcCompareRequest.cs
@@ -56,21 +56,21 @@ namespace Novell.Directory.Ldap.Rfc2251
         ///     Constructs a new Compare Request copying from the data of
         ///     an existing request.
         /// </summary>
-        internal RfcCompareRequest(Asn1Object[] origRequest, string baseRenamed)
+        internal RfcCompareRequest(Asn1Object[] origRequest, string baseDn)
             : base(origRequest, origRequest.Length)
         {
             // Replace the base if specified, otherwise keep original base
-            if (baseRenamed != null)
+            if (baseDn != null)
             {
-                this[0] = new RfcLdapDn(baseRenamed);
+                this[0] = new RfcLdapDn(baseDn);
             }
         }
 
         public RfcAttributeValueAssertion AttributeValueAssertion => (RfcAttributeValueAssertion)this[1];
 
-        public IRfcRequest DupRequest(string baseRenamed, string filter, bool request)
+        public IRfcRequest DupRequest(string baseDn, string filter, bool request)
         {
-            return new RfcCompareRequest(ToArray(), baseRenamed);
+            return new RfcCompareRequest(ToArray(), baseDn);
         }
 
         public string GetRequestDn()

--- a/src/Novell.Directory.Ldap.NETStandard/Rfc2251/RfcCompareRequest.cs
+++ b/src/Novell.Directory.Ldap.NETStandard/Rfc2251/RfcCompareRequest.cs
@@ -62,11 +62,11 @@ namespace Novell.Directory.Ldap.Rfc2251
             // Replace the base if specified, otherwise keep original base
             if (baseRenamed != null)
             {
-                set_Renamed(0, new RfcLdapDn(baseRenamed));
+                this[0] = new RfcLdapDn(baseRenamed);
             }
         }
 
-        public RfcAttributeValueAssertion AttributeValueAssertion => (RfcAttributeValueAssertion)get_Renamed(1);
+        public RfcAttributeValueAssertion AttributeValueAssertion => (RfcAttributeValueAssertion)this[1];
 
         public IRfcRequest DupRequest(string baseRenamed, string filter, bool request)
         {
@@ -75,7 +75,7 @@ namespace Novell.Directory.Ldap.Rfc2251
 
         public string GetRequestDn()
         {
-            return ((RfcLdapDn)get_Renamed(0)).StringValue();
+            return ((RfcLdapDn)this[0]).StringValue();
         }
 
         // *************************************************************************

--- a/src/Novell.Directory.Ldap.NETStandard/Rfc2251/RfcCompareResponse.cs
+++ b/src/Novell.Directory.Ldap.NETStandard/Rfc2251/RfcCompareResponse.cs
@@ -42,8 +42,8 @@ namespace Novell.Directory.Ldap.Rfc2251
         ///     The only time a client will create a CompareResponse is when it is
         ///     decoding it from an InputStream.
         /// </summary>
-        public RfcCompareResponse(IAsn1Decoder dec, Stream inRenamed, int len)
-            : base(dec, inRenamed, len)
+        public RfcCompareResponse(IAsn1Decoder dec, Stream input, int len)
+            : base(dec, input, len)
         {
         }
 

--- a/src/Novell.Directory.Ldap.NETStandard/Rfc2251/RfcControl.cs
+++ b/src/Novell.Directory.Ldap.NETStandard/Rfc2251/RfcControl.cs
@@ -74,8 +74,8 @@ namespace Novell.Directory.Ldap.Rfc2251
         }
 
         /// <summary> Constructs a Control object by decoding it from an InputStream.</summary>
-        public RfcControl(IAsn1Decoder dec, Stream inRenamed, int len)
-            : base(dec, inRenamed, len)
+        public RfcControl(IAsn1Decoder dec, Stream input, int len)
+            : base(dec, input, len)
         {
         }
 

--- a/src/Novell.Directory.Ldap.NETStandard/Rfc2251/RfcControl.cs
+++ b/src/Novell.Directory.Ldap.NETStandard/Rfc2251/RfcControl.cs
@@ -83,15 +83,15 @@ namespace Novell.Directory.Ldap.Rfc2251
         public RfcControl(Asn1Sequence seqObj)
             : base(3)
         {
-            var len = seqObj.Size();
+            var len = seqObj.Count;
             for (var i = 0; i < len; i++)
             {
-                Add(seqObj.get_Renamed(i));
+                Add(seqObj[i]);
             }
         }
 
         /// <summary> </summary>
-        public Asn1OctetString ControlType => (Asn1OctetString)get_Renamed(0);
+        public Asn1OctetString ControlType => (Asn1OctetString)this[0];
 
         /// <summary>
         ///     Returns criticality.
@@ -101,13 +101,13 @@ namespace Novell.Directory.Ldap.Rfc2251
         {
             get
             {
-                if (Size() > 1)
+                if (Count > 1)
                 {
                     // MAY be a criticality
-                    var obj = get_Renamed(1);
-                    if (obj is Asn1Boolean)
+                    var obj = this[1];
+                    if (obj is Asn1Boolean boolean)
                     {
-                        return (Asn1Boolean)obj;
+                        return boolean;
                     }
                 }
 
@@ -128,19 +128,19 @@ namespace Novell.Directory.Ldap.Rfc2251
         {
             get
             {
-                if (Size() > 2)
+                if (Count > 2)
                 {
                     // MUST be a control value
-                    return (Asn1OctetString)get_Renamed(2);
+                    return (Asn1OctetString)this[2];
                 }
 
-                if (Size() > 1)
+                if (Count > 1)
                 {
                     // MAY be a control value
-                    var obj = get_Renamed(1);
-                    if (obj is Asn1OctetString)
+                    var obj = this[1];
+                    if (obj is Asn1OctetString octetString)
                     {
-                        return (Asn1OctetString)obj;
+                        return octetString;
                     }
                 }
 
@@ -154,23 +154,23 @@ namespace Novell.Directory.Ldap.Rfc2251
                     return;
                 }
 
-                if (Size() == 3)
+                if (Count == 3)
                 {
                     // We already have a control value, replace it
-                    set_Renamed(2, value);
+                    this[2] = value;
                     return;
                 }
 
-                if (Size() == 2)
+                if (Count == 2)
                 {
                     // Get the second element
-                    var obj = get_Renamed(1);
+                    var obj = this[1];
 
                     // Is this a control value
                     if (obj is Asn1OctetString)
                     {
                         // replace this one
-                        set_Renamed(1, value);
+                        this[1] = value;
                     }
                     else
                     {

--- a/src/Novell.Directory.Ldap.NETStandard/Rfc2251/RfcControls.cs
+++ b/src/Novell.Directory.Ldap.NETStandard/Rfc2251/RfcControls.cs
@@ -56,10 +56,10 @@ namespace Novell.Directory.Ldap.Rfc2251
             : base(dec, inRenamed, len)
         {
             // Convert each SEQUENCE element to a Control
-            for (var i = 0; i < Size(); i++)
+            for (var i = 0; i < Count; i++)
             {
-                var tempControl = new RfcControl((Asn1Sequence)get_Renamed(i));
-                set_Renamed(i, tempControl);
+                var tempControl = new RfcControl((Asn1Sequence)base[i]);
+                this[i] = tempControl;
             }
         }
 
@@ -73,10 +73,10 @@ namespace Novell.Directory.Ldap.Rfc2251
             base.Add(control);
         }
 
-        /// <summary> Override set() of Asn1SequenceOf to only accept a Control type.</summary>
-        public void set_Renamed(int index, RfcControl control)
+        public new RfcControl this[int index]
         {
-            base.set_Renamed(index, control);
+            get => (RfcControl)base[index];
+            set => base[index] = value;
         }
 
         // *************************************************************************

--- a/src/Novell.Directory.Ldap.NETStandard/Rfc2251/RfcControls.cs
+++ b/src/Novell.Directory.Ldap.NETStandard/Rfc2251/RfcControls.cs
@@ -52,8 +52,8 @@ namespace Novell.Directory.Ldap.Rfc2251
         }
 
         /// <summary> Constructs a Controls object by decoding it from an InputStream.</summary>
-        public RfcControls(IAsn1Decoder dec, Stream inRenamed, int len)
-            : base(dec, inRenamed, len)
+        public RfcControls(IAsn1Decoder dec, Stream input, int len)
+            : base(dec, input, len)
         {
             // Convert each SEQUENCE element to a Control
             for (var i = 0; i < Count; i++)

--- a/src/Novell.Directory.Ldap.NETStandard/Rfc2251/RfcDelRequest.cs
+++ b/src/Novell.Directory.Ldap.NETStandard/Rfc2251/RfcDelRequest.cs
@@ -59,14 +59,14 @@ namespace Novell.Directory.Ldap.Rfc2251
         {
         }
 
-        public IRfcRequest DupRequest(string baseRenamed, string filter, bool request)
+        public IRfcRequest DupRequest(string baseDn, string filter, bool request)
         {
-            if (baseRenamed == null)
+            if (baseDn == null)
             {
                 return new RfcDelRequest(ByteValue());
             }
 
-            return new RfcDelRequest(baseRenamed);
+            return new RfcDelRequest(baseDn);
         }
 
         public string GetRequestDn()

--- a/src/Novell.Directory.Ldap.NETStandard/Rfc2251/RfcDelResponse.cs
+++ b/src/Novell.Directory.Ldap.NETStandard/Rfc2251/RfcDelResponse.cs
@@ -42,8 +42,8 @@ namespace Novell.Directory.Ldap.Rfc2251
         ///     The only time a client will create a DelResponse is when it is
         ///     decoding it from an InputStream.
         /// </summary>
-        public RfcDelResponse(IAsn1Decoder dec, Stream inRenamed, int len)
-            : base(dec, inRenamed, len)
+        public RfcDelResponse(IAsn1Decoder dec, Stream input, int len)
+            : base(dec, input, len)
         {
         }
 

--- a/src/Novell.Directory.Ldap.NETStandard/Rfc2251/RfcExtendedRequest.cs
+++ b/src/Novell.Directory.Ldap.NETStandard/Rfc2251/RfcExtendedRequest.cs
@@ -87,7 +87,7 @@ namespace Novell.Directory.Ldap.Rfc2251
         {
         }
 
-        public IRfcRequest DupRequest(string baseRenamed, string filter, bool request)
+        public IRfcRequest DupRequest(string baseDn, string filter, bool request)
         {
             // Just dup the original request
             return new RfcExtendedRequest(ToArray());

--- a/src/Novell.Directory.Ldap.NETStandard/Rfc2251/RfcExtendedResponse.cs
+++ b/src/Novell.Directory.Ldap.NETStandard/Rfc2251/RfcExtendedResponse.cs
@@ -59,28 +59,28 @@ namespace Novell.Directory.Ldap.Rfc2251
             : base(dec, inRenamed, len)
         {
             // decode optional tagged elements
-            if (Size() > 3)
+            if (Count > 3)
             {
-                for (var i = 3; i < Size(); i++)
+                for (var i = 3; i < Count; i++)
                 {
-                    var obj = (Asn1Tagged)get_Renamed(i);
+                    var obj = (Asn1Tagged)this[i];
                     var id = obj.GetIdentifier();
                     switch (id.Tag)
                     {
                         case RfcLdapResult.Referral:
                             var content = ((Asn1OctetString)obj.TaggedValue).ByteValue();
                             var bais = new MemoryStream(content);
-                            set_Renamed(i, new RfcReferral(dec, bais, content.Length));
+                            this[i] = new RfcReferral(dec, bais, content.Length);
                             _referralIndex = i;
                             break;
 
                         case ResponseNameTag:
-                            set_Renamed(i, new RfcLdapOid(((Asn1OctetString)obj.TaggedValue).ByteValue()));
+                            this[i] = new RfcLdapOid(((Asn1OctetString)obj.TaggedValue).ByteValue());
                             _responseNameIndex = i;
                             break;
 
                         case ResponseTag:
-                            set_Renamed(i, obj.TaggedValue);
+                            this[i] = obj.TaggedValue;
                             _responseIndex = i;
                             break;
                     }
@@ -89,10 +89,10 @@ namespace Novell.Directory.Ldap.Rfc2251
         }
 
         /// <summary> </summary>
-        public RfcLdapOid ResponseName => _responseNameIndex != 0 ? (RfcLdapOid)get_Renamed(_responseNameIndex) : null;
+        public RfcLdapOid ResponseName => _responseNameIndex != 0 ? (RfcLdapOid)this[_responseNameIndex] : null;
 
         /// <summary> </summary>
-        public Asn1OctetString Response => _responseIndex != 0 ? (Asn1OctetString)get_Renamed(_responseIndex) : null;
+        public Asn1OctetString Response => _responseIndex != 0 ? (Asn1OctetString)this[_responseIndex] : null;
 
         // *************************************************************************
         // Accessors
@@ -101,25 +101,25 @@ namespace Novell.Directory.Ldap.Rfc2251
         /// <summary> </summary>
         public Asn1Enumerated GetResultCode()
         {
-            return (Asn1Enumerated)get_Renamed(0);
+            return (Asn1Enumerated)this[0];
         }
 
         /// <summary> </summary>
         public RfcLdapDn GetMatchedDn()
         {
-            return new RfcLdapDn(((Asn1OctetString)get_Renamed(1)).ByteValue());
+            return new RfcLdapDn(((Asn1OctetString)this[1]).ByteValue());
         }
 
         /// <summary> </summary>
         public RfcLdapString GetErrorMessage()
         {
-            return new RfcLdapString(((Asn1OctetString)get_Renamed(2)).ByteValue());
+            return new RfcLdapString(((Asn1OctetString)this[2]).ByteValue());
         }
 
         /// <summary> </summary>
         public RfcReferral GetReferral()
         {
-            return _referralIndex != 0 ? (RfcReferral)get_Renamed(_referralIndex) : null;
+            return _referralIndex != 0 ? (RfcReferral)this[_referralIndex] : null;
         }
 
         /// <summary> Override getIdentifier to return an application-wide id.</summary>

--- a/src/Novell.Directory.Ldap.NETStandard/Rfc2251/RfcExtendedResponse.cs
+++ b/src/Novell.Directory.Ldap.NETStandard/Rfc2251/RfcExtendedResponse.cs
@@ -55,8 +55,8 @@ namespace Novell.Directory.Ldap.Rfc2251
         ///     The only time a client will create a ExtendedResponse is when it is
         ///     decoding it from an InputStream.
         /// </summary>
-        public RfcExtendedResponse(IAsn1Decoder dec, Stream inRenamed, int len)
-            : base(dec, inRenamed, len)
+        public RfcExtendedResponse(IAsn1Decoder dec, Stream input, int len)
+            : base(dec, input, len)
         {
             // decode optional tagged elements
             if (Count > 3)

--- a/src/Novell.Directory.Ldap.NETStandard/Rfc2251/RfcFilter.cs
+++ b/src/Novell.Directory.Ldap.NETStandard/Rfc2251/RfcFilter.cs
@@ -253,7 +253,7 @@ namespace Novell.Directory.Ldap.Rfc2251
 
                 default:
                     var filterType = _ft.FilterType;
-                    var valueRenamed = _ft.Value;
+                    var value = _ft.Value;
 
                     switch (filterType)
                     {
@@ -264,22 +264,22 @@ namespace Novell.Directory.Ldap.Rfc2251
                                 new Asn1Identifier(Asn1Identifier.Context, true, filterType),
                                 new RfcAttributeValueAssertion(
                                     new RfcAttributeDescription(_ft.Attr),
-                                    new RfcAssertionValue(UnescapeString(valueRenamed))), false);
+                                    new RfcAssertionValue(UnescapeString(value))), false);
                             break;
 
                         case EqualityMatch:
-                            if (valueRenamed.Equals("*"))
+                            if (value.Equals("*"))
                             {
                                 // present
                                 tag = new Asn1Tagged(
                                     new Asn1Identifier(Asn1Identifier.Context, false, Present),
                                     new RfcAttributeDescription(_ft.Attr), false);
                             }
-                            else if (valueRenamed.IndexOf('*') != -1)
+                            else if (value.IndexOf('*') != -1)
                             {
                                 // substrings parse:
                                 //    [initial], *any*, [final] into an Asn1SequenceOf
-                                var sub = new Tokenizer(valueRenamed, "*", true);
+                                var sub = new Tokenizer(value, "*", true);
 
                                 // SupportClass.Tokenizer sub = new SupportClass.Tokenizer(value_Renamed, "*");//, true);
                                 var seq = new Asn1SequenceOf(5);
@@ -348,7 +348,7 @@ namespace Novell.Directory.Ldap.Rfc2251
                                     new Asn1Identifier(Asn1Identifier.Context, true, EqualityMatch),
                                     new RfcAttributeValueAssertion(
                                         new RfcAttributeDescription(_ft.Attr),
-                                        new RfcAssertionValue(UnescapeString(valueRenamed))), false);
+                                        new RfcAssertionValue(UnescapeString(value))), false);
                             }
 
                             break;
@@ -387,7 +387,7 @@ namespace Novell.Directory.Ldap.Rfc2251
                                 new RfcMatchingRuleAssertion(
                                     matchingRule == null ? null : new RfcMatchingRuleId(matchingRule),
                                     type == null ? null : new RfcAttributeDescription(type),
-                                    new RfcAssertionValue(UnescapeString(valueRenamed)),
+                                    new RfcAssertionValue(UnescapeString(value)),
                                     dnAttributes == false ? null : new Asn1Boolean(true)), false);
                             break;
                     }
@@ -433,16 +433,16 @@ namespace Novell.Directory.Ldap.Rfc2251
         ///     V2: \*,  \(,  \),  \\.
         ///     V3: \2A, \28, \29, \5C, \00.
         /// </summary>
-        /// <param name="stringRenamed">
+        /// <param name="inputString">
         ///     A part of the input filter string to be converted.
         /// </param>
         /// <returns>
         ///     octet-string encoding of the specified string.
         /// </returns>
-        private byte[] UnescapeString(string stringRenamed)
+        private byte[] UnescapeString(string inputString)
         {
             // give octets enough space to grow
-            var octets = new byte[stringRenamed.Length * 3];
+            var octets = new byte[inputString.Length * 3];
 
             // index for string and octets
             int iString, iOctets;
@@ -453,7 +453,7 @@ namespace Novell.Directory.Ldap.Rfc2251
             // escStart==true means we are reading the first character of an escape.
             var escStart = false;
 
-            int ival, length = stringRenamed.Length;
+            int ival, length = inputString.Length;
             byte[] utf8Bytes;
             char ch; // Character we are adding to the octet string
             var temp = (char)0; // holds the value of the escaped sequence
@@ -462,8 +462,8 @@ namespace Novell.Directory.Ldap.Rfc2251
             // converting escaped sequences when needed
             for (iString = 0, iOctets = 0; iString < length; iString++)
             {
-                ch = stringRenamed[iString];
-                var codePoint = char.ConvertToUtf32(stringRenamed, iString);
+                ch = inputString[iString];
+                var codePoint = char.ConvertToUtf32(inputString, iString);
                 if (codePoint > 0xffff)
                 {
                     iString++;
@@ -655,12 +655,12 @@ namespace Novell.Directory.Ldap.Rfc2251
         /// <param name="type">
         ///     Substring type: INITIAL | ANY | FINAL].
         /// </param>
-        /// <param name="valueRenamed">
+        /// <param name="value">
         ///     Value to use for matching
         ///     @throws LdapLocalException   Occurs if this method is called out of
         ///     sequence or the type added is out of sequence.
         /// </param>
-        public void AddSubstring(int type, byte[] valueRenamed)
+        public void AddSubstring(int type, byte[] value)
         {
             try
             {
@@ -693,7 +693,7 @@ namespace Novell.Directory.Ldap.Rfc2251
 
                 substringSeq.Add(new Asn1Tagged(
                     new Asn1Identifier(Asn1Identifier.Context, false, type),
-                    new RfcLdapString(valueRenamed), false));
+                    new RfcLdapString(value), false));
             }
             catch (InvalidCastException e)
             {
@@ -737,14 +737,14 @@ namespace Novell.Directory.Ldap.Rfc2251
         /// <param name="attrName">
         ///     Name of the attribute to be asserted.
         /// </param>
-        /// <param name="valueRenamed">
+        /// <param name="value">
         ///     Value of the attribute to be asserted
         ///     @throws LdapLocalException
         ///     Occurs when the filter type is not a valid attribute assertion.
         /// </param>
-        public void AddAttributeValueAssertion(int rfcType, string attrName, byte[] valueRenamed)
+        public void AddAttributeValueAssertion(int rfcType, string attrName, byte[] value)
         {
-            if (_filterStack != null && !(_filterStack.Count == 0) && _filterStack.Peek() is Asn1SequenceOf)
+            if (_filterStack != null && _filterStack.Count != 0 && _filterStack.Peek() is Asn1SequenceOf)
             {
                 // If a sequenceof is on the stack then substring is left on the stack
                 throw new LdapLocalException(
@@ -764,7 +764,7 @@ namespace Novell.Directory.Ldap.Rfc2251
                 new Asn1Identifier(Asn1Identifier.Context, true, rfcType),
                 new RfcAttributeValueAssertion(
                     new RfcAttributeDescription(attrName),
-                    new RfcAssertionValue(valueRenamed)), false);
+                    new RfcAssertionValue(value)), false);
             AddObject(current);
         }
 
@@ -793,7 +793,7 @@ namespace Novell.Directory.Ldap.Rfc2251
         /// <param name="attrName">
         ///     Name of the attribute to match.
         /// </param>
-        /// <param name="valueRenamed">
+        /// <param name="value">
         ///     Value of the attribute to match against.
         /// </param>
         /// <param name="useDnMatching">
@@ -801,14 +801,14 @@ namespace Novell.Directory.Ldap.Rfc2251
         ///     @throws LdapLocalException
         ///     Occurs when addExtensibleMatch is called out of sequence.
         /// </param>
-        public void AddExtensibleMatch(string matchingRule, string attrName, byte[] valueRenamed, bool useDnMatching)
+        public void AddExtensibleMatch(string matchingRule, string attrName, byte[] value, bool useDnMatching)
         {
             Asn1Object current = new Asn1Tagged(
                 new Asn1Identifier(Asn1Identifier.Context, true, ExtensibleMatch),
                 new RfcMatchingRuleAssertion(
                     matchingRule == null ? null : new RfcMatchingRuleId(matchingRule),
                     attrName == null ? null : new RfcAttributeDescription(attrName),
-                    new RfcAssertionValue(valueRenamed), useDnMatching == false ? null : new Asn1Boolean(true)), false);
+                    new RfcAssertionValue(value), useDnMatching == false ? null : new Asn1Boolean(true)), false);
             AddObject(current);
         }
 
@@ -932,8 +932,8 @@ namespace Novell.Directory.Ldap.Rfc2251
                                 filter.Append('=');
 
                                 itr.MoveNext();
-                                var valueRenamed = (byte[])itr.Current;
-                                filter.Append(ByteString(valueRenamed));
+                                var value = (byte[])itr.Current;
+                                filter.Append(ByteString(value));
                                 break;
                             }
 
@@ -945,8 +945,8 @@ namespace Novell.Directory.Ldap.Rfc2251
                                 filter.Append(">=");
 
                                 itr.MoveNext();
-                                var valueRenamed = (byte[])itr.Current;
-                                filter.Append(ByteString(valueRenamed));
+                                var value = (byte[])itr.Current;
+                                filter.Append(ByteString(value));
                                 break;
                             }
 
@@ -958,8 +958,8 @@ namespace Novell.Directory.Ldap.Rfc2251
                                 filter.Append("<=");
 
                                 itr.MoveNext();
-                                var valueRenamed = (byte[])itr.Current;
-                                filter.Append(ByteString(valueRenamed));
+                                var value = (byte[])itr.Current;
+                                filter.Append(ByteString(value));
                                 break;
                             }
 
@@ -970,28 +970,32 @@ namespace Novell.Directory.Ldap.Rfc2251
                             break;
 
                         case ApproxMatch:
-                            itr.MoveNext();
-                            filter.Append((string)itr.Current);
+                            {
+                                itr.MoveNext();
+                                filter.Append((string)itr.Current);
 
-                            filter.Append("~=");
+                                filter.Append("~=");
 
-                            itr.MoveNext();
-                            var valueRenamed2 = (byte[])itr.Current;
-                            filter.Append(ByteString(valueRenamed2));
-                            break;
+                                itr.MoveNext();
+                                var value = (byte[])itr.Current;
+                                filter.Append(ByteString(value));
+                                break;
+                            }
 
                         case ExtensibleMatch:
-                            itr.MoveNext();
-                            var oid = (string)itr.Current;
+                            {
+                                itr.MoveNext();
+                                var oid = (string)itr.Current;
 
-                            itr.MoveNext();
-                            filter.Append((string)itr.Current);
-                            filter.Append(':');
-                            filter.Append(oid);
-                            filter.Append(":=");
-                            itr.MoveNext();
-                            filter.Append((string)itr.Current);
-                            break;
+                                itr.MoveNext();
+                                filter.Append((string)itr.Current);
+                                filter.Append(':');
+                                filter.Append(oid);
+                                filter.Append(":=");
+                                itr.MoveNext();
+                                filter.Append((string)itr.Current);
+                                break;
+                            }
 
                         case Substrings:
                             {
@@ -1125,8 +1129,8 @@ namespace Novell.Directory.Ldap.Rfc2251
                             yield return tag.GetIdentifier().Tag;
 
                             // return substring value
-                            var valueRenamed = (RfcLdapString)tag.TaggedValue;
-                            yield return valueRenamed.StringValue();
+                            var value = (RfcLdapString)tag.TaggedValue;
+                            yield return value.StringValue();
                         }
 
                         yield break;
@@ -1161,9 +1165,9 @@ namespace Novell.Directory.Ldap.Rfc2251
                 case Asn1SetOf setOf:
                     {
                         // AND and OR nested components
-                        foreach (Asn1Tagged renamed in setOf)
+                        foreach (Asn1Tagged tagged in setOf)
                         {
-                            yield return FilterEnumerable(renamed);
+                            yield return FilterEnumerable(tagged);
                         }
 
                         yield break;

--- a/src/Novell.Directory.Ldap.NETStandard/Rfc2251/RfcIntermediateResponse.cs
+++ b/src/Novell.Directory.Ldap.NETStandard/Rfc2251/RfcIntermediateResponse.cs
@@ -95,7 +95,7 @@ namespace Novell.Directory.Ldap.Rfc2251
             // have decoded these elements as ASN1Tagged objects with the value
             // stored as an ASN1OctectString object.
             // the incorrectly encoded case, LDAPResult contains
-            if (Size() >= 3)
+            if (Count >= 3)
             {
                 i = 3; // at least 3 components
             }
@@ -104,20 +104,20 @@ namespace Novell.Directory.Ldap.Rfc2251
                 i = 0; // correctly encoded case, can have zero components
             }
 
-            for (; i < Size(); i++)
+            for (; i < Count; i++)
             {
-                var obj = (Asn1Tagged)get_Renamed(i);
+                var obj = (Asn1Tagged)this[i];
                 var id = obj.GetIdentifier();
                 switch (id.Tag)
                 {
                     case TagResponseName:
-                        set_Renamed(i, new RfcLdapOid(
-                            ((Asn1OctetString)obj.TaggedValue).ByteValue()));
+                        this[i] = new RfcLdapOid(
+                            ((Asn1OctetString)obj.TaggedValue).ByteValue());
                         _mResponseNameIndex = i;
                         break;
 
                     case TagResponse:
-                        set_Renamed(i, obj.TaggedValue);
+                        this[i] = obj.TaggedValue;
                         _mResponseValueIndex = i;
                         break;
                 }
@@ -126,9 +126,9 @@ namespace Novell.Directory.Ldap.Rfc2251
 
         public Asn1Enumerated GetResultCode()
         {
-            if (Size() > 3)
+            if (Count > 3)
             {
-                return (Asn1Enumerated)get_Renamed(0);
+                return (Asn1Enumerated)this[0];
             }
 
             return null;
@@ -136,9 +136,9 @@ namespace Novell.Directory.Ldap.Rfc2251
 
         public RfcLdapDn GetMatchedDn()
         {
-            if (Size() > 3)
+            if (Count > 3)
             {
-                return new RfcLdapDn(((Asn1OctetString)get_Renamed(1)).ByteValue());
+                return new RfcLdapDn(((Asn1OctetString)this[1]).ByteValue());
             }
 
             return null;
@@ -146,9 +146,9 @@ namespace Novell.Directory.Ldap.Rfc2251
 
         public RfcLdapString GetErrorMessage()
         {
-            if (Size() > 3)
+            if (Count > 3)
             {
-                return new RfcLdapString(((Asn1OctetString)get_Renamed(2)).ByteValue());
+                return new RfcLdapString(((Asn1OctetString)this[2]).ByteValue());
             }
 
             return null;
@@ -156,20 +156,20 @@ namespace Novell.Directory.Ldap.Rfc2251
 
         public RfcReferral GetReferral()
         {
-            return Size() > 3 ? (RfcReferral)get_Renamed(3) : null;
+            return Count > 3 ? (RfcReferral)this[3] : null;
         }
 
         public RfcLdapOid GetResponseName()
         {
             return _mResponseNameIndex >= 0
-                ? (RfcLdapOid)get_Renamed(_mResponseNameIndex)
+                ? (RfcLdapOid)this[_mResponseNameIndex]
                 : null;
         }
 
         public Asn1OctetString GetResponse()
         {
             return _mResponseValueIndex != 0
-                ? (Asn1OctetString)get_Renamed(_mResponseValueIndex)
+                ? (Asn1OctetString)this[_mResponseValueIndex]
                 : null;
         }
 

--- a/src/Novell.Directory.Ldap.NETStandard/Rfc2251/RfcIntermediateResponse.cs
+++ b/src/Novell.Directory.Ldap.NETStandard/Rfc2251/RfcIntermediateResponse.cs
@@ -84,8 +84,8 @@ namespace Novell.Directory.Ldap.Rfc2251
          * oid of the response. The element at m_responseValueIndex will be set
          * to an ASN1OctetString containing the value bytes.
          */
-        public RfcIntermediateResponse(IAsn1Decoder dec, Stream inRenamed, int len)
-            : base(dec, inRenamed, len)
+        public RfcIntermediateResponse(IAsn1Decoder dec, Stream input, int len)
+            : base(dec, input, len)
         {
             _mResponseNameIndex = _mResponseValueIndex = 0;
 

--- a/src/Novell.Directory.Ldap.NETStandard/Rfc2251/RfcLdapMessage.cs
+++ b/src/Novell.Directory.Ldap.NETStandard/Rfc2251/RfcLdapMessage.cs
@@ -128,8 +128,8 @@ namespace Novell.Directory.Ldap.Rfc2251
         }
 
         /// <summary> Will decode an RfcLdapMessage directly from an InputStream.</summary>
-        public RfcLdapMessage(IAsn1Decoder dec, Stream inRenamed, int len)
-            : base(dec, inRenamed, len)
+        public RfcLdapMessage(IAsn1Decoder dec, Stream input, int len)
+            : base(dec, input, len)
         {
             // Decode implicitly tagged protocol operation from an Asn1Tagged type
             // to its appropriate application type.

--- a/src/Novell.Directory.Ldap.NETStandard/Rfc2251/RfcLdapMessage.cs
+++ b/src/Novell.Directory.Ldap.NETStandard/Rfc2251/RfcLdapMessage.cs
@@ -77,12 +77,12 @@ namespace Novell.Directory.Ldap.Rfc2251
             bool reference)
             : base(origContent, origContent.Length)
         {
-            set_Renamed(0, new RfcMessageId()); // MessageID has static counter
+            this[0] = new RfcMessageId(); // MessageID has static counter
 
             var req = (IRfcRequest)origContent[1];
             var newreq = req.DupRequest(dn, filter, reference);
             _op = (Asn1Object)newreq;
-            set_Renamed(1, (Asn1Object)newreq);
+            this[1] = (Asn1Object)newreq;
         }
 
         /// <summary> Create an RfcLdapMessage using the specified Ldap Request.</summary>
@@ -133,7 +133,7 @@ namespace Novell.Directory.Ldap.Rfc2251
         {
             // Decode implicitly tagged protocol operation from an Asn1Tagged type
             // to its appropriate application type.
-            var protocolOp = (Asn1Tagged)get_Renamed(1);
+            var protocolOp = (Asn1Tagged)this[1];
             var protocolOpId = protocolOp.GetIdentifier();
             var content = ((Asn1OctetString)protocolOp.TaggedValue).ByteValue();
             var bais = new MemoryStream(content);
@@ -141,47 +141,47 @@ namespace Novell.Directory.Ldap.Rfc2251
             switch (protocolOpId.Tag)
             {
                 case LdapMessage.SearchResponse:
-                    set_Renamed(1, new RfcSearchResultEntry(dec, bais, content.Length));
+                    this[1] = new RfcSearchResultEntry(dec, bais, content.Length);
                     break;
 
                 case LdapMessage.SearchResult:
-                    set_Renamed(1, new RfcSearchResultDone(dec, bais, content.Length));
+                    this[1] = new RfcSearchResultDone(dec, bais, content.Length);
                     break;
 
                 case LdapMessage.SearchResultReference:
-                    set_Renamed(1, new RfcSearchResultReference(dec, bais, content.Length));
+                    this[1] = new RfcSearchResultReference(dec, bais, content.Length);
                     break;
 
                 case LdapMessage.AddResponse:
-                    set_Renamed(1, new RfcAddResponse(dec, bais, content.Length));
+                    this[1] = new RfcAddResponse(dec, bais, content.Length);
                     break;
 
                 case LdapMessage.BindResponse:
-                    set_Renamed(1, new RfcBindResponse(dec, bais, content.Length));
+                    this[1] = new RfcBindResponse(dec, bais, content.Length);
                     break;
 
                 case LdapMessage.CompareResponse:
-                    set_Renamed(1, new RfcCompareResponse(dec, bais, content.Length));
+                    this[1] = new RfcCompareResponse(dec, bais, content.Length);
                     break;
 
                 case LdapMessage.DelResponse:
-                    set_Renamed(1, new RfcDelResponse(dec, bais, content.Length));
+                    this[1] = new RfcDelResponse(dec, bais, content.Length);
                     break;
 
                 case LdapMessage.ExtendedResponse:
-                    set_Renamed(1, new RfcExtendedResponse(dec, bais, content.Length));
+                    this[1] = new RfcExtendedResponse(dec, bais, content.Length);
                     break;
 
                 case LdapMessage.IntermediateResponse:
-                    set_Renamed(1, new RfcIntermediateResponse(dec, bais, content.Length));
+                    this[1] = new RfcIntermediateResponse(dec, bais, content.Length);
                     break;
 
                 case LdapMessage.ModifyResponse:
-                    set_Renamed(1, new RfcModifyResponse(dec, bais, content.Length));
+                    this[1] = new RfcModifyResponse(dec, bais, content.Length);
                     break;
 
                 case LdapMessage.ModifyRdnResponse:
-                    set_Renamed(1, new RfcModifyDnResponse(dec, bais, content.Length));
+                    this[1] = new RfcModifyDnResponse(dec, bais, content.Length);
                     break;
 
                 default:
@@ -190,23 +190,23 @@ namespace Novell.Directory.Ldap.Rfc2251
 
             // decode optional implicitly tagged controls from Asn1Tagged type to
             // to RFC 2251 types.
-            if (Size() > 2)
+            if (Count > 2)
             {
-                var controls = (Asn1Tagged)get_Renamed(2);
+                var controls = (Asn1Tagged)this[2];
 
                 // Asn1Identifier controlsId = protocolOp.getIdentifier();
                 // we could check to make sure we have controls here....
                 content = ((Asn1OctetString)controls.TaggedValue).ByteValue();
                 bais = new MemoryStream(content);
-                set_Renamed(2, new RfcControls(dec, bais, content.Length));
+                this[2] = new RfcControls(dec, bais, content.Length);
             }
         }
 
         /// <summary> Returns this RfcLdapMessage's messageID as an int.</summary>
-        public int MessageId => ((Asn1Integer)get_Renamed(0)).IntValue();
+        public int MessageId => ((Asn1Integer)this[0]).IntValue();
 
         /// <summary> Returns this RfcLdapMessage's message type.</summary>
-        public int Type => get_Renamed(1).GetIdentifier().Tag;
+        public int Type => this[1].GetIdentifier().Tag;
 
         /// <summary>
         ///     Returns the response associated with this RfcLdapMessage.
@@ -214,16 +214,16 @@ namespace Novell.Directory.Ldap.Rfc2251
         ///     all which extend RfcResponse. It can also be
         ///     RfcSearchResultEntry, or RfcSearchResultReference.
         /// </summary>
-        public Asn1Object Response => get_Renamed(1);
+        public Asn1Object Response => this[1];
 
         /// <summary> Returns the optional Controls for this RfcLdapMessage.</summary>
         public RfcControls Controls
         {
             get
             {
-                if (Size() > 2)
+                if (Count > 2)
                 {
-                    return (RfcControls)get_Renamed(2);
+                    return (RfcControls)this[2];
                 }
 
                 return null;
@@ -254,12 +254,12 @@ namespace Novell.Directory.Ldap.Rfc2251
         /// </summary>
         public IRfcRequest GetRequest()
         {
-            return (IRfcRequest)get_Renamed(1);
+            return (IRfcRequest)this[1];
         }
 
         public bool IsRequest()
         {
-            return get_Renamed(1) is IRfcRequest;
+            return this[1] is IRfcRequest;
         }
 
         /// <summary>
@@ -284,7 +284,7 @@ namespace Novell.Directory.Ldap.Rfc2251
                 throw new LdapException("DUP_ERROR", LdapException.LocalError, null);
             }
 
-            var newMsg = new RfcLdapMessage(ToArray(), (IRfcRequest)get_Renamed(1), dn, filter, reference);
+            var newMsg = new RfcLdapMessage(ToArray(), (IRfcRequest)this[1], dn, filter, reference);
             return newMsg;
         }
     }

--- a/src/Novell.Directory.Ldap.NETStandard/Rfc2251/RfcLdapResult.cs
+++ b/src/Novell.Directory.Ldap.NETStandard/Rfc2251/RfcLdapResult.cs
@@ -138,8 +138,8 @@ namespace Novell.Directory.Ldap.Rfc2251
         }
 
         /// <summary> Constructs an RfcLdapResult from the inputstream.</summary>
-        public RfcLdapResult(IAsn1Decoder dec, Stream inRenamed, int len)
-            : base(dec, inRenamed, len)
+        public RfcLdapResult(IAsn1Decoder dec, Stream input, int len)
+            : base(dec, input, len)
         {
             // Decode optional referral from Asn1OctetString to Referral.
             if (Count > 3)

--- a/src/Novell.Directory.Ldap.NETStandard/Rfc2251/RfcLdapResult.cs
+++ b/src/Novell.Directory.Ldap.NETStandard/Rfc2251/RfcLdapResult.cs
@@ -142,15 +142,15 @@ namespace Novell.Directory.Ldap.Rfc2251
             : base(dec, inRenamed, len)
         {
             // Decode optional referral from Asn1OctetString to Referral.
-            if (Size() > 3)
+            if (Count > 3)
             {
-                var obj = (Asn1Tagged)get_Renamed(3);
+                var obj = (Asn1Tagged)this[3];
                 var id = obj.GetIdentifier();
                 if (id.Tag == Referral)
                 {
                     var content = ((Asn1OctetString)obj.TaggedValue).ByteValue();
                     var bais = new MemoryStream(content);
-                    set_Renamed(3, new RfcReferral(dec, bais, content.Length));
+                    this[3] = new RfcReferral(dec, bais, content.Length);
                 }
             }
         }
@@ -167,7 +167,7 @@ namespace Novell.Directory.Ldap.Rfc2251
         /// </returns>
         public Asn1Enumerated GetResultCode()
         {
-            return (Asn1Enumerated)get_Renamed(0);
+            return (Asn1Enumerated)this[0];
         }
 
         /// <summary>
@@ -178,7 +178,7 @@ namespace Novell.Directory.Ldap.Rfc2251
         /// </returns>
         public RfcLdapDn GetMatchedDn()
         {
-            return new RfcLdapDn(((Asn1OctetString)get_Renamed(1)).ByteValue());
+            return new RfcLdapDn(((Asn1OctetString)this[1]).ByteValue());
         }
 
         /// <summary>
@@ -189,7 +189,7 @@ namespace Novell.Directory.Ldap.Rfc2251
         /// </returns>
         public RfcLdapString GetErrorMessage()
         {
-            return new RfcLdapString(((Asn1OctetString)get_Renamed(2)).ByteValue());
+            return new RfcLdapString(((Asn1OctetString)this[2]).ByteValue());
         }
 
         /// <summary>
@@ -200,7 +200,7 @@ namespace Novell.Directory.Ldap.Rfc2251
         /// </returns>
         public RfcReferral GetReferral()
         {
-            return Size() > 3 ? (RfcReferral)get_Renamed(3) : null;
+            return Count > 3 ? (RfcReferral)this[3] : null;
         }
     }
 }

--- a/src/Novell.Directory.Ldap.NETStandard/Rfc2251/RfcLdapString.cs
+++ b/src/Novell.Directory.Ldap.NETStandard/Rfc2251/RfcLdapString.cs
@@ -42,8 +42,8 @@ namespace Novell.Directory.Ldap.Rfc2251
         }
 
         /// <summary> </summary>
-        public RfcLdapString(IAsn1Decoder dec, Stream inRenamed, int len)
-            : base(dec, inRenamed, len)
+        public RfcLdapString(IAsn1Decoder dec, Stream input, int len)
+            : base(dec, input, len)
         {
         }
     }

--- a/src/Novell.Directory.Ldap.NETStandard/Rfc2251/RfcMessageID.cs
+++ b/src/Novell.Directory.Ldap.NETStandard/Rfc2251/RfcMessageID.cs
@@ -41,11 +41,11 @@ namespace Novell.Directory.Ldap.Rfc2251
     internal class RfcMessageId : Asn1Integer
     {
         private static int _messageId;
-        private static readonly object LockRenamed;
+        private static readonly object Lock;
 
         static RfcMessageId()
         {
-            LockRenamed = new object();
+            Lock = new object();
         }
 
         /// <summary>
@@ -75,7 +75,7 @@ namespace Novell.Directory.Ldap.Rfc2251
         {
             get
             {
-                lock (LockRenamed)
+                lock (Lock)
                 {
                     return _messageId < int.MaxValue ? ++_messageId : (_messageId = 1);
                 }

--- a/src/Novell.Directory.Ldap.NETStandard/Rfc2251/RfcModifyDNRequest.cs
+++ b/src/Novell.Directory.Ldap.NETStandard/Rfc2251/RfcModifyDNRequest.cs
@@ -66,19 +66,19 @@ namespace Novell.Directory.Ldap.Rfc2251
         ///     Constructs a new Delete Request copying from the ArrayList of
         ///     an existing request.
         /// </summary>
-        internal RfcModifyDnRequest(Asn1Object[] origRequest, string baseRenamed)
+        internal RfcModifyDnRequest(Asn1Object[] origRequest, string baseDn)
             : base(origRequest, origRequest.Length)
         {
             // Replace the base if specified, otherwise keep original base
-            if (baseRenamed != null)
+            if (baseDn != null)
             {
-                this[0] = new RfcLdapDn(baseRenamed);
+                this[0] = new RfcLdapDn(baseDn);
             }
         }
 
-        public IRfcRequest DupRequest(string baseRenamed, string filter, bool request)
+        public IRfcRequest DupRequest(string baseDn, string filter, bool request)
         {
-            return new RfcModifyDnRequest(ToArray(), baseRenamed);
+            return new RfcModifyDnRequest(ToArray(), baseDn);
         }
 
         public string GetRequestDn()

--- a/src/Novell.Directory.Ldap.NETStandard/Rfc2251/RfcModifyDNRequest.cs
+++ b/src/Novell.Directory.Ldap.NETStandard/Rfc2251/RfcModifyDNRequest.cs
@@ -72,7 +72,7 @@ namespace Novell.Directory.Ldap.Rfc2251
             // Replace the base if specified, otherwise keep original base
             if (baseRenamed != null)
             {
-                set_Renamed(0, new RfcLdapDn(baseRenamed));
+                this[0] = new RfcLdapDn(baseRenamed);
             }
         }
 
@@ -83,7 +83,7 @@ namespace Novell.Directory.Ldap.Rfc2251
 
         public string GetRequestDn()
         {
-            return ((RfcLdapDn)get_Renamed(0)).StringValue();
+            return ((RfcLdapDn)this[0]).StringValue();
         }
 
         // *************************************************************************

--- a/src/Novell.Directory.Ldap.NETStandard/Rfc2251/RfcModifyDNResponse.cs
+++ b/src/Novell.Directory.Ldap.NETStandard/Rfc2251/RfcModifyDNResponse.cs
@@ -39,8 +39,8 @@ namespace Novell.Directory.Ldap.Rfc2251
         // *************************************************************************
 
         /// <summary> Create a ModifyDNResponse by decoding it from an InputStream.</summary>
-        public RfcModifyDnResponse(IAsn1Decoder dec, Stream inRenamed, int len)
-            : base(dec, inRenamed, len)
+        public RfcModifyDnResponse(IAsn1Decoder dec, Stream input, int len)
+            : base(dec, input, len)
         {
         }
 

--- a/src/Novell.Directory.Ldap.NETStandard/Rfc2251/RfcModifyRequest.cs
+++ b/src/Novell.Directory.Ldap.NETStandard/Rfc2251/RfcModifyRequest.cs
@@ -45,10 +45,10 @@ namespace Novell.Directory.Ldap.Rfc2251
         // *************************************************************************
 
         /// <summary> </summary>
-        public RfcModifyRequest(RfcLdapDn objectRenamed, Asn1SequenceOf modification)
+        public RfcModifyRequest(RfcLdapDn objectToModify, Asn1SequenceOf modification)
             : base(2)
         {
-            Add(objectRenamed);
+            Add(objectToModify);
             Add(modification);
         }
 
@@ -56,13 +56,13 @@ namespace Novell.Directory.Ldap.Rfc2251
         ///     Constructs a new Modify Request copying from the ArrayList of
         ///     an existing request.
         /// </summary>
-        internal RfcModifyRequest(Asn1Object[] origRequest, string baseRenamed)
+        internal RfcModifyRequest(Asn1Object[] origRequest, string baseDn)
             : base(origRequest, origRequest.Length)
         {
             // Replace the base if specified, otherwise keep original base
-            if (baseRenamed != null)
+            if (baseDn != null)
             {
-                this[0] = new RfcLdapDn(baseRenamed);
+                this[0] = new RfcLdapDn(baseDn);
             }
         }
 
@@ -74,9 +74,9 @@ namespace Novell.Directory.Ldap.Rfc2251
         /// </returns>
         public Asn1SequenceOf Modifications => (Asn1SequenceOf)this[1];
 
-        public IRfcRequest DupRequest(string baseRenamed, string filter, bool request)
+        public IRfcRequest DupRequest(string baseDn, string filter, bool request)
         {
-            return new RfcModifyRequest(ToArray(), baseRenamed);
+            return new RfcModifyRequest(ToArray(), baseDn);
         }
 
         /// <summary>

--- a/src/Novell.Directory.Ldap.NETStandard/Rfc2251/RfcModifyRequest.cs
+++ b/src/Novell.Directory.Ldap.NETStandard/Rfc2251/RfcModifyRequest.cs
@@ -62,7 +62,7 @@ namespace Novell.Directory.Ldap.Rfc2251
             // Replace the base if specified, otherwise keep original base
             if (baseRenamed != null)
             {
-                set_Renamed(0, new RfcLdapDn(baseRenamed));
+                this[0] = new RfcLdapDn(baseRenamed);
             }
         }
 
@@ -72,7 +72,7 @@ namespace Novell.Directory.Ldap.Rfc2251
         /// <returns>
         ///     the modifications for this request.
         /// </returns>
-        public Asn1SequenceOf Modifications => (Asn1SequenceOf)get_Renamed(1);
+        public Asn1SequenceOf Modifications => (Asn1SequenceOf)this[1];
 
         public IRfcRequest DupRequest(string baseRenamed, string filter, bool request)
         {
@@ -87,7 +87,7 @@ namespace Novell.Directory.Ldap.Rfc2251
         /// </returns>
         public string GetRequestDn()
         {
-            return ((RfcLdapDn)get_Renamed(0)).StringValue();
+            return ((RfcLdapDn)this[0]).StringValue();
         }
 
         // *************************************************************************

--- a/src/Novell.Directory.Ldap.NETStandard/Rfc2251/RfcModifyResponse.cs
+++ b/src/Novell.Directory.Ldap.NETStandard/Rfc2251/RfcModifyResponse.cs
@@ -42,8 +42,8 @@ namespace Novell.Directory.Ldap.Rfc2251
         ///     The only time a client will create a ModifyResponse is when it is
         ///     decoding it from an InputStream.
         /// </summary>
-        public RfcModifyResponse(IAsn1Decoder dec, Stream inRenamed, int len)
-            : base(dec, inRenamed, len)
+        public RfcModifyResponse(IAsn1Decoder dec, Stream input, int len)
+            : base(dec, input, len)
         {
         }
 

--- a/src/Novell.Directory.Ldap.NETStandard/Rfc2251/RfcReferral.cs
+++ b/src/Novell.Directory.Ldap.NETStandard/Rfc2251/RfcReferral.cs
@@ -42,8 +42,8 @@ namespace Novell.Directory.Ldap.Rfc2251
         ///     The only time a Referral object is constructed, is when we are
         ///     decoding an RfcLdapResult or COMPONENTS OF RfcLdapResult.
         /// </summary>
-        public RfcReferral(IAsn1Decoder dec, Stream inRenamed, int len)
-            : base(dec, inRenamed, len)
+        public RfcReferral(IAsn1Decoder dec, Stream input, int len)
+            : base(dec, input, len)
         {
             // convert from Asn1OctetString to RfcLdapURL here (then look at
             // LdapResponse.getReferrals())

--- a/src/Novell.Directory.Ldap.NETStandard/Rfc2251/RfcRequest.cs
+++ b/src/Novell.Directory.Ldap.NETStandard/Rfc2251/RfcRequest.cs
@@ -30,7 +30,7 @@ namespace Novell.Directory.Ldap.Rfc2251
     public interface IRfcRequest
     {
         /// <summary> Builds a new request using the data from the this object.</summary>
-        IRfcRequest DupRequest(string baseRenamed, string filter, bool reference);
+        IRfcRequest DupRequest(string baseDn, string filter, bool reference);
 
         /// <summary> Builds a new request using the data from the this object.</summary>
         string GetRequestDn();

--- a/src/Novell.Directory.Ldap.NETStandard/Rfc2251/RfcSearchRequest.cs
+++ b/src/Novell.Directory.Ldap.NETStandard/Rfc2251/RfcSearchRequest.cs
@@ -78,7 +78,7 @@ namespace Novell.Directory.Ldap.Rfc2251
             // Replace the base if specified, otherwise keep original base
             if (baseRenamed != null)
             {
-                set_Renamed(0, new RfcLdapDn(baseRenamed));
+                this[0] = new RfcLdapDn(baseRenamed);
             }
 
             // If this is a reencode of a search continuation reference
@@ -89,14 +89,14 @@ namespace Novell.Directory.Ldap.Rfc2251
                 var scope = ((Asn1Enumerated)origRequest[1]).IntValue();
                 if (scope == LdapConnection.ScopeOne)
                 {
-                    set_Renamed(1, new Asn1Enumerated(LdapConnection.ScopeBase));
+                    this[1] = new Asn1Enumerated(LdapConnection.ScopeBase);
                 }
             }
 
             // Replace the filter if specified, otherwise keep original filter
             if (filter != null)
             {
-                set_Renamed(6, new RfcFilter(filter));
+                this[6] = new RfcFilter(filter);
             }
         }
 
@@ -107,7 +107,7 @@ namespace Novell.Directory.Ldap.Rfc2251
 
         public string GetRequestDn()
         {
-            return ((RfcLdapDn)get_Renamed(0)).StringValue();
+            return ((RfcLdapDn)this[0]).StringValue();
         }
 
         // *************************************************************************

--- a/src/Novell.Directory.Ldap.NETStandard/Rfc2251/RfcSearchRequest.cs
+++ b/src/Novell.Directory.Ldap.NETStandard/Rfc2251/RfcSearchRequest.cs
@@ -72,13 +72,13 @@ namespace Novell.Directory.Ldap.Rfc2251
         }
 
         /// <summary> Constructs a new Search Request copying from an existing request.</summary>
-        internal RfcSearchRequest(Asn1Object[] origRequest, string baseRenamed, string filter, bool request)
+        internal RfcSearchRequest(Asn1Object[] origRequest, string baseDn, string filter, bool request)
             : base(origRequest, origRequest.Length)
         {
             // Replace the base if specified, otherwise keep original base
-            if (baseRenamed != null)
+            if (baseDn != null)
             {
-                this[0] = new RfcLdapDn(baseRenamed);
+                this[0] = new RfcLdapDn(baseDn);
             }
 
             // If this is a reencode of a search continuation reference
@@ -100,9 +100,9 @@ namespace Novell.Directory.Ldap.Rfc2251
             }
         }
 
-        public IRfcRequest DupRequest(string baseRenamed, string filter, bool request)
+        public IRfcRequest DupRequest(string baseDn, string filter, bool request)
         {
-            return new RfcSearchRequest(ToArray(), baseRenamed, filter, request);
+            return new RfcSearchRequest(ToArray(), baseDn, filter, request);
         }
 
         public string GetRequestDn()

--- a/src/Novell.Directory.Ldap.NETStandard/Rfc2251/RfcSearchResultDone.cs
+++ b/src/Novell.Directory.Ldap.NETStandard/Rfc2251/RfcSearchResultDone.cs
@@ -39,8 +39,8 @@ namespace Novell.Directory.Ldap.Rfc2251
         // *************************************************************************
 
         /// <summary> Decode a search result done from the input stream.</summary>
-        public RfcSearchResultDone(IAsn1Decoder dec, Stream inRenamed, int len)
-            : base(dec, inRenamed, len)
+        public RfcSearchResultDone(IAsn1Decoder dec, Stream input, int len)
+            : base(dec, input, len)
         {
         }
 

--- a/src/Novell.Directory.Ldap.NETStandard/Rfc2251/RfcSearchResultEntry.cs
+++ b/src/Novell.Directory.Ldap.NETStandard/Rfc2251/RfcSearchResultEntry.cs
@@ -56,10 +56,10 @@ namespace Novell.Directory.Ldap.Rfc2251
         }
 
         /// <summary> </summary>
-        public Asn1OctetString ObjectName => (Asn1OctetString)get_Renamed(0);
+        public Asn1OctetString ObjectName => (Asn1OctetString)this[0];
 
         /// <summary> </summary>
-        public Asn1Sequence Attributes => (Asn1Sequence)get_Renamed(1);
+        public Asn1Sequence Attributes => (Asn1Sequence)this[1];
 
         // *************************************************************************
         // Accessors

--- a/src/Novell.Directory.Ldap.NETStandard/Rfc2251/RfcSearchResultEntry.cs
+++ b/src/Novell.Directory.Ldap.NETStandard/Rfc2251/RfcSearchResultEntry.cs
@@ -44,8 +44,8 @@ namespace Novell.Directory.Ldap.Rfc2251
         ///     The only time a client will create a SearchResultEntry is when it is
         ///     decoding it from an InputStream.
         /// </summary>
-        public RfcSearchResultEntry(IAsn1Decoder dec, Stream inRenamed, int len)
-            : base(dec, inRenamed, len)
+        public RfcSearchResultEntry(IAsn1Decoder dec, Stream input, int len)
+            : base(dec, input, len)
         {
             // Decode objectName
             //      set(0, new RfcLdapDN(((Asn1OctetString)get(0)).stringValue()));

--- a/src/Novell.Directory.Ldap.NETStandard/Rfc2251/RfcSearchResultReference.cs
+++ b/src/Novell.Directory.Ldap.NETStandard/Rfc2251/RfcSearchResultReference.cs
@@ -42,8 +42,8 @@ namespace Novell.Directory.Ldap.Rfc2251
         ///     The only time a client will create a SearchResultReference is when it is
         ///     decoding it from an InputStream.
         /// </summary>
-        public RfcSearchResultReference(IAsn1Decoder dec, Stream inRenamed, int len)
-            : base(dec, inRenamed, len)
+        public RfcSearchResultReference(IAsn1Decoder dec, Stream input, int len)
+            : base(dec, input, len)
         {
         }
 

--- a/src/Novell.Directory.Ldap.NETStandard/Rfc2251/RfcUnbindRequest.cs
+++ b/src/Novell.Directory.Ldap.NETStandard/Rfc2251/RfcUnbindRequest.cs
@@ -34,7 +34,7 @@ namespace Novell.Directory.Ldap.Rfc2251
     /// </summary>
     public class RfcUnbindRequest : Asn1Null, IRfcRequest
     {
-        public IRfcRequest DupRequest(string baseRenamed, string filter, bool request)
+        public IRfcRequest DupRequest(string baseDn, string filter, bool request)
         {
             throw new LdapException(ExceptionMessages.NoDupRequest, new object[] { "unbind" },
                 LdapException.LdapNotSupported, null);

--- a/src/Novell.Directory.Ldap.NETStandard/Utilclass/AttributeQualifier.cs
+++ b/src/Novell.Directory.Ldap.NETStandard/Utilclass/AttributeQualifier.cs
@@ -33,16 +33,16 @@ namespace Novell.Directory.Ldap.Utilclass
     {
         private readonly string[] _values;
 
-        public AttributeQualifier(string name, string[] valueRenamed)
+        public AttributeQualifier(string name, string[] value)
         {
-            if (name == null || valueRenamed == null)
+            if (name == null || value == null)
             {
                 throw new ArgumentException("A null name or value " +
                                             "was passed in for a schema definition qualifier");
             }
 
             Name = name;
-            _values = (string[])valueRenamed.Clone();
+            _values = (string[])value.Clone();
         }
 
         public string Name { get; }

--- a/src/Novell.Directory.Ldap.NETStandard/Utilclass/SchemaTokenCreator.cs
+++ b/src/Novell.Directory.Ldap.NETStandard/Utilclass/SchemaTokenCreator.cs
@@ -356,7 +356,7 @@ namespace Novell.Directory.Ldap.Utilclass
                     {
                         checkdec = 1;
                     }
-                    else if (curc >= '0' && curc <= '9')
+                    else if (curc is >= '0' and <= '9')
                     {
                         dvar = (dvar * 10) + (curc - '0');
                         tempvar += checkdec;
@@ -430,15 +430,15 @@ namespace Novell.Directory.Ldap.Utilclass
                     {
                         curc = Read();
                         var first = curc;
-                        if (curc >= '0' && curc <= '7')
+                        if (curc is >= '0' and <= '7')
                         {
                             curc = curc - '0';
                             var loopchar = Read();
-                            if (loopchar >= '0' && loopchar <= '7')
+                            if (loopchar is >= '0' and <= '7')
                             {
                                 curc = (curc << 3) + (loopchar - '0');
                                 loopchar = Read();
-                                if (loopchar >= '0' && loopchar <= '7' && first <= '3')
+                                if (loopchar is >= '0' and <= '7' && first <= '3')
                                 {
                                     curc = (curc << 3) + (loopchar - '0');
                                     rc = Read();


### PR DESCRIPTION
95% of the PR is getting `renamed` out of the name of symbols. The remaining 5% try to let the code feel a bit more C# like and a bit less Java like, by e.g. implementing `IReadOnlyList<Asn1Object>` in `Asn1Structured` instead of having `set_Renamed`, `get_Renamed` and `Size()`.