### PR TITLE
feat: Implement LDAP Password Modify Extended Operation

### DIFF
--- a/src/Novell.Directory.Ldap.NETStandard/LdapExtensions/ExtensionRegistrations.cs
+++ b/src/Novell.Directory.Ldap.NETStandard/LdapExtensions/ExtensionRegistrations.cs
@@ -8,6 +8,7 @@ namespace Novell.Directory.Ldap
         static ExtensionRegistrations()
         {
             LdapExtendedResponse.Register(LdapKnownOids.Extensions.WhoAmI, message => new LdapWhoAmIResponse(message));
+            LdapExtendedResponse.Register(LdapKnownOids.Extensions.PasswordModify, message => new LdapPasswordModifyResponse(message));
         }
 
         public static Task<LdapWhoAmIResponse> WhoAmIAsync(this LdapConnection conn, CancellationToken ct = default)
@@ -24,6 +25,24 @@ namespace Novell.Directory.Ldap
             }
 
             return new LdapWhoAmIResponse(result.Message);
+        }
+
+        public static Task<LdapPasswordModifyResponse> PasswordModifyAsync(
+            this ILdapConnection conn, string userIdentity, string oldPasswd, string newPasswd, CancellationToken ct = default)
+        {
+            return conn.PasswordModifyAsync(null, userIdentity, oldPasswd, newPasswd, ct);
+        }
+
+        public static async Task<LdapPasswordModifyResponse> PasswordModifyAsync(
+            this ILdapConnection conn, LdapConstraints cons, string userIdentity, string oldPasswd, string newPasswd, CancellationToken ct = default)
+        {
+            var result = await conn.ExtendedOperationAsync(new LdapPasswordModifyOperation(userIdentity, oldPasswd, newPasswd), cons, ct).ConfigureAwait(false);
+            if (result is LdapPasswordModifyResponse pwmod)
+            {
+                return pwmod;
+            }
+
+            return new LdapPasswordModifyResponse(result.Message);
         }
     }
 }

--- a/src/Novell.Directory.Ldap.NETStandard/LdapExtensions/LdapKnownOids.cs
+++ b/src/Novell.Directory.Ldap.NETStandard/LdapExtensions/LdapKnownOids.cs
@@ -11,19 +11,25 @@ namespace Novell.Directory.Ldap
             /// https://tools.ietf.org/html/rfc4532.
             /// </summary>
             public const string WhoAmI = "1.3.6.1.4.1.4203.1.11.3";
-            public const string StartTls = "1.3.6.1.4.1.1466.20037";
-            public const string DynamicRefresh = "1.3.6.1.4.1.1466.101.119.1";
-            public const string FastConcurrentBind = "1.2.840.113556.1.4.1781";
-            public const string ModifyPassword = "1.3.6.1.4.1.4203.1.11.1";
-            public const string GracefulDisconnect = "1.3.6.1.4.1.18060.0.1.5";
-            public const string GracefulShutdownRequest = "1.3.6.1.4.1.18060.0.1.3";
-            public const string NoticeOfDisconnection = "1.3.6.1.4.1.1466.20036";
+
+            /// <summary>
+            /// RFC 3063: LDAP Password Modify Extended Operation
+            /// https://tools.ietf.org/html/rfc3062.
+            /// </summary>
+            public const string PasswordModify = "1.3.6.1.4.1.4203.1.11.1";
 
             /// <summary>
             /// LDAP_SERVER_BATCH_REQUEST_OID
             /// https://msdn.microsoft.com/en-us/library/jj217379.aspx.
             /// </summary>
             public const string ServerBatchRequest = "1.2.840.113556.1.4.2212";
+
+            public const string StartTls = "1.3.6.1.4.1.1466.20037";
+            public const string DynamicRefresh = "1.3.6.1.4.1.1466.101.119.1";
+            public const string FastConcurrentBind = "1.2.840.113556.1.4.1781";
+            public const string GracefulDisconnect = "1.3.6.1.4.1.18060.0.1.5";
+            public const string GracefulShutdownRequest = "1.3.6.1.4.1.18060.0.1.3";
+            public const string NoticeOfDisconnection = "1.3.6.1.4.1.1466.20036";
         }
 
         private static readonly IReadOnlyDictionary<string, string> _oidNames = new Dictionary<string, string>
@@ -32,7 +38,7 @@ namespace Novell.Directory.Ldap
             [Extensions.StartTls] = "Start TLS",
             [Extensions.DynamicRefresh] = "Dynamic Refresh",
             [Extensions.FastConcurrentBind] = "Fast concurrent Bind",
-            [Extensions.ModifyPassword] = "Modify Password (RFC 3062)",
+            [Extensions.PasswordModify] = "Password Modify (RFC 3062)",
             [Extensions.GracefulDisconnect] = "Graceful Disconnect",
             [Extensions.GracefulShutdownRequest] = "Graceful Shutdown Request",
             [Extensions.NoticeOfDisconnection] = "Notice of Disconnection",

--- a/src/Novell.Directory.Ldap.NETStandard/LdapExtensions/LdapPasswordModifyOperation.cs
+++ b/src/Novell.Directory.Ldap.NETStandard/LdapExtensions/LdapPasswordModifyOperation.cs
@@ -1,0 +1,120 @@
+﻿using Novell.Directory.Ldap.Asn1;
+using Novell.Directory.Ldap.Rfc2251;
+using System.IO;
+
+namespace Novell.Directory.Ldap
+{
+    /// <summary>
+    /// RFC 3063: LDAP Password Modify Extended Operation
+    /// https://tools.ietf.org/html/rfc3062.
+    /// </summary>
+    /// <pre>
+    /// PasswdModifyRequestValue::= SEQUENCE {
+    ///   userIdentity[0]  OCTET STRING OPTIONAL,
+    ///   oldPasswd[1]     OCTET STRING OPTIONAL,
+    ///   newPasswd[2]     OCTET STRING OPTIONAL }
+    /// </pre>
+    public class LdapPasswordModifyOperation : LdapExtendedOperation
+    {
+        public override DebugId DebugId { get; } = DebugId.ForType<LdapPasswordModifyOperation>();
+
+        /// <summary> Context-specific tag for optional userIdentity.</summary>
+        private const int UserIdentityTag = 0;
+
+        /// <summary> Context-specific tag for optional oldPasswd.</summary>
+        private const int OldPasswdTag = 1;
+
+        /// <summary> Context-specific tag for optional newPasswd.</summary>
+        private const int NewPasswdTag = 2;
+
+        /// <summary>
+        /// According to RFC 4511 Section 5.1:
+        /// The OCTET STRING type must always be encoded in the primitive (not constructed) form.
+        /// </summary>
+        private const bool ConstructedType = false;
+
+        /// <summary>
+        /// According to the complete ASN.1 definition in RFC 4511, Appendix B:
+        /// Tags are always implicit (not explicit) unless otherwise stated.
+        /// </summary>
+        private const bool ExplicitTag = false;
+
+        /// <summary>
+        /// Constructs an LDAP Password Modify Extended Operation.
+        /// </summary>
+        /// <param name="userIdentity">
+        /// A string that identifies the user whose password will be changed.
+        /// This does not have to be a Distinguished Name but usually it is.
+        /// Can be null or empty in which case the LDAP server is supposed to
+        /// use the currently bound user.</param>
+        /// <param name="oldPasswd">
+        /// The user's current password. Used to authenticate the operation.
+        /// Can be null or empty in which case the behavior is unspecified.
+        /// Usually a null or empty oldPasswd will result in an error but some
+        /// servers may allow it if certain conditions are met. For example,
+        /// if the currently bound user is the RootDN user.
+        /// </param>
+        /// <param name="newPasswd">
+        /// The desired new password. Can be null or empty in which case the
+        /// LDAP server is supposed to generate a new password and send it
+        /// with the response message (the 'genPasswd' field).  Some servers
+        /// may not support or allow password generation and will send an
+        /// error response instead.
+        /// </param>
+        public LdapPasswordModifyOperation(string userIdentity, string oldPasswd, string newPasswd)
+            : base(LdapKnownOids.Extensions.PasswordModify, null)
+        {
+            var seq = new Asn1Sequence(3);
+
+            if (!string.IsNullOrEmpty(userIdentity))
+            {
+                var octetString = new Asn1OctetString(userIdentity);
+                var id = new Asn1Identifier(Asn1Identifier.Context, ConstructedType, UserIdentityTag);
+
+                seq.Add(new Asn1Tagged(id, octetString, ExplicitTag));
+            }
+
+            if (!string.IsNullOrEmpty(oldPasswd))
+            {
+                var octetString = new Asn1OctetString(oldPasswd);
+                var id = new Asn1Identifier(Asn1Identifier.Context, ConstructedType, OldPasswdTag);
+
+                seq.Add(new Asn1Tagged(id, octetString, ExplicitTag));
+            }
+
+            if (!string.IsNullOrEmpty(newPasswd))
+            {
+                var octetString = new Asn1OctetString(newPasswd);
+                var id = new Asn1Identifier(Asn1Identifier.Context, ConstructedType, NewPasswdTag);
+
+                seq.Add(new Asn1Tagged(id, octetString, ExplicitTag));
+            }
+
+            var stream = new MemoryStream();
+            seq.Encode(new LberEncoder(), stream);
+
+            SetValue(stream.ToArray());
+        }
+    }
+
+    /// <summary>
+    /// RFC 3063: LDAP Password Modify Extended Operation
+    /// https://tools.ietf.org/html/rfc3062.
+    /// </summary>
+    /// <pre>
+    /// PasswdModifyResponseValue ::= SEQUENCE {
+    ///   genPasswd[0] OCTET STRING OPTIONAL }
+    /// </pre>
+    public class LdapPasswordModifyResponse : LdapExtendedResponse
+    {
+        public override DebugId DebugId { get; } = DebugId.ForType<LdapPasswordModifyResponse>();
+
+        public string genPasswd { get; }
+
+        public LdapPasswordModifyResponse(RfcLdapMessage message)
+            : base(message)
+        {
+            genPasswd = ((RfcExtendedResponse)message.Response)?.Response?.StringValue();
+        }
+    }
+}

--- a/src/Novell.Directory.Ldap.NETStandard/LdapExtensions/LdapPasswordModifyOperation.cs
+++ b/src/Novell.Directory.Ldap.NETStandard/LdapExtensions/LdapPasswordModifyOperation.cs
@@ -7,13 +7,13 @@ namespace Novell.Directory.Ldap
     /// <summary>
     /// RFC 3063: LDAP Password Modify Extended Operation
     /// https://tools.ietf.org/html/rfc3062.
+    ///   <pre>
+    ///     PasswdModifyRequestValue::= SEQUENCE {
+    ///       userIdentity[0]  OCTET STRING OPTIONAL,
+    ///       oldPasswd[1]     OCTET STRING OPTIONAL,
+    ///       newPasswd[2]     OCTET STRING OPTIONAL }
+    ///   </pre>
     /// </summary>
-    /// <pre>
-    /// PasswdModifyRequestValue::= SEQUENCE {
-    ///   userIdentity[0]  OCTET STRING OPTIONAL,
-    ///   oldPasswd[1]     OCTET STRING OPTIONAL,
-    ///   newPasswd[2]     OCTET STRING OPTIONAL }
-    /// </pre>
     public class LdapPasswordModifyOperation : LdapExtendedOperation
     {
         public override DebugId DebugId { get; } = DebugId.ForType<LdapPasswordModifyOperation>();
@@ -100,11 +100,11 @@ namespace Novell.Directory.Ldap
     /// <summary>
     /// RFC 3063: LDAP Password Modify Extended Operation
     /// https://tools.ietf.org/html/rfc3062.
+    ///   <pre>
+    ///     PasswdModifyResponseValue ::= SEQUENCE {
+    ///       genPasswd[0] OCTET STRING OPTIONAL }
+    ///   </pre>
     /// </summary>
-    /// <pre>
-    /// PasswdModifyResponseValue ::= SEQUENCE {
-    ///   genPasswd[0] OCTET STRING OPTIONAL }
-    /// </pre>
     public class LdapPasswordModifyResponse : LdapExtendedResponse
     {
         public override DebugId DebugId { get; } = DebugId.ForType<LdapPasswordModifyResponse>();

--- a/test/Novell.Directory.Ldap.NETStandard.FunctionalTests/ModifyPasswordTests.cs
+++ b/test/Novell.Directory.Ldap.NETStandard.FunctionalTests/ModifyPasswordTests.cs
@@ -24,6 +24,17 @@ namespace Novell.Directory.Ldap.NETStandard.FunctionalTests
                 async ldapConnection =>
                 {
                     await ldapConnection.BindAsync(existingEntry.Dn, newPassword);
+
+                    // Check to see if the other password modify extension is supported and test that too
+                    var rootDse = await ldapConnection.GetRootDseInfoAsync();
+                    if (rootDse.SupportsExtension(LdapKnownOids.Extensions.PasswordModify))
+                    {
+                        var oldPassword = newPassword;
+                        newPassword = "password" + new Random().Next();
+
+                        await ldapConnection.PasswordModifyAsync(existingEntry.Dn, oldPassword, newPassword);
+                        await ldapConnection.BindAsync(existingEntry.Dn, newPassword);
+                    }
                 });
         }
     }

--- a/test/Novell.Directory.Ldap.NETStandard.FunctionalTests/ModifyPasswordTests.cs
+++ b/test/Novell.Directory.Ldap.NETStandard.FunctionalTests/ModifyPasswordTests.cs
@@ -24,21 +24,6 @@ namespace Novell.Directory.Ldap.NETStandard.FunctionalTests
                 async ldapConnection =>
                 {
                     await ldapConnection.BindAsync(existingEntry.Dn, newPassword);
-
-                    // Check to see if the password modify extension is supported and test that too
-                    var rootDse = await ldapConnection.GetRootDseInfoAsync();
-                    if (rootDse.SupportsExtension(LdapKnownOids.Extensions.PasswordModify))
-                    {
-                        var oldPassword = newPassword;
-                        newPassword = "password" + new Random().Next();
-
-                        // Users don't have permission to change their own passwords in the
-                        // test environment so perform the change as the RootUserDn
-                        await ldapConnection.BindAsync(TestsConfig.LdapServer.RootUserDn, TestsConfig.LdapServer.RootUserPassword);
-                        await ldapConnection.PasswordModifyAsync(existingEntry.Dn, oldPassword, newPassword);
-
-                        await ldapConnection.BindAsync(existingEntry.Dn, newPassword);
-                    }
                 });
         }
     }

--- a/test/Novell.Directory.Ldap.NETStandard.FunctionalTests/ModifyPasswordTests.cs
+++ b/test/Novell.Directory.Ldap.NETStandard.FunctionalTests/ModifyPasswordTests.cs
@@ -25,14 +25,18 @@ namespace Novell.Directory.Ldap.NETStandard.FunctionalTests
                 {
                     await ldapConnection.BindAsync(existingEntry.Dn, newPassword);
 
-                    // Check to see if the other password modify extension is supported and test that too
+                    // Check to see if the password modify extension is supported and test that too
                     var rootDse = await ldapConnection.GetRootDseInfoAsync();
                     if (rootDse.SupportsExtension(LdapKnownOids.Extensions.PasswordModify))
                     {
                         var oldPassword = newPassword;
                         newPassword = "password" + new Random().Next();
 
+                        // Users don't have permission to change their own passwords in the
+                        // test environment so perform the change as the RootUserDn
+                        await ldapConnection.BindAsync(TestsConfig.LdapServer.RootUserDn, TestsConfig.LdapServer.RootUserPassword);
                         await ldapConnection.PasswordModifyAsync(existingEntry.Dn, oldPassword, newPassword);
+
                         await ldapConnection.BindAsync(existingEntry.Dn, newPassword);
                     }
                 });

--- a/test/Novell.Directory.Ldap.NETStandard.FunctionalTests/PasswordModifyExtendedOperationTests.cs
+++ b/test/Novell.Directory.Ldap.NETStandard.FunctionalTests/PasswordModifyExtendedOperationTests.cs
@@ -1,0 +1,39 @@
+﻿using Novell.Directory.Ldap.NETStandard.FunctionalTests.Helpers;
+using System;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Novell.Directory.Ldap.NETStandard.FunctionalTests
+{
+    public class PasswordModifyExtendedOperationTests
+    {
+        [Fact]
+        public async Task PasswordModifyExtendedOperation_OfExistingEntry_ShouldWork()
+        {
+            var existingEntry = await LdapOps.AddEntryAsync();
+            var oldPassword = TestsConfig.DefaultPassword;
+
+            await TestHelper.WithLdapConnectionAsync(
+                async ldapConnection =>
+                {
+                    // Make sure the credentials work
+                    await ldapConnection.BindAsync(existingEntry.Dn, oldPassword);
+
+                    var newPassword = "password" + new Random().Next();
+
+                    // Users don't have permission to change their own passwords in the
+                    // test environment, so perform the change as the RootUserDn
+                    await ldapConnection.BindAsync(TestsConfig.LdapServer.RootUserDn, TestsConfig.LdapServer.RootUserPassword);
+                    await ldapConnection.PasswordModifyAsync(existingEntry.Dn, oldPassword, newPassword);
+
+                    // The new password should work
+                    await ldapConnection.BindAsync(existingEntry.Dn, newPassword);
+
+                    // The old password should no longer work
+                    var ldapException = await Assert.ThrowsAsync<LdapException>(async () => { await ldapConnection.BindAsync(existingEntry.Dn, oldPassword); });
+
+                    Assert.Equal(LdapException.InvalidCredentials, ldapException.ResultCode);
+                });
+        }
+    }
+}


### PR DESCRIPTION
Adds support for the LDAP Password Modify Extended Operation specified in [RFC 3062](https://datatracker.ietf.org/doc/html/rfc3062).

I also added code to the functional tests to make sure this is working.  I haven't actually run the functional tests because I don't have Ubuntu or WSL right now...  and instead of just getting them I decided to be lazy and let the CI run the tests.  But I have built the library and written some external code that uses this and I can confirm that it works with OpenLDAP.